### PR TITLE
Fix handling of a disconnect with multiple connections

### DIFF
--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -133,7 +133,6 @@ class Hci extends EventEmitter {
   }
 
   resetBuffers () {
-    this._mainHandle = null;
     this._handleAclsInProgress = {};
     this._handleBuffers = {};
     this._aclOutQueue = [];
@@ -527,7 +526,7 @@ class Hci extends EventEmitter {
       if (subEventType === EVT_DISCONN_COMPLETE) {
         handle = data.readUInt16LE(4);
         debug('\t\thandle = ' + handle);
-        if (handle !== this._mainHandle) {
+        if (this._handleAclsInProgress[handle] === undefined) {
           debug('\tignoring event because handle is unknown to bleno.');
           debug('This might be OK in a multi role scenario in which the handle is part of a noble connection.');
           return;
@@ -543,7 +542,6 @@ class Hci extends EventEmitter {
         Controller for the returned Handle have been flushed, and that the
         corresponding data buffers have been freed. */
         delete this._handleAclsInProgress[handle];
-        this._mainHandle = null;
         const aclOutQueue = [];
         let discarded = 0;
         for (const i in this._aclOutQueue) {
@@ -789,7 +787,6 @@ class Hci extends EventEmitter {
     debug('\t\t\tsupervision timeout = ' + supervisionTimeout);
     debug('\t\t\tmaster clock accuracy = ' + masterClockAccuracy);
 
-    this._mainHandle = handle;
     this._handleAclsInProgress[handle] = 0;
 
     this.emit('leConnComplete', status, handle, role, addressType, address, interval, latency, supervisionTimeout, masterClockAccuracy);


### PR DESCRIPTION
Found an issue and a fix for a problem with handling a connection disconnecting when multiple connections are involved.

To reproduce the issue, run a simple Bleno process with `DEBUG=*`:
- Connect with device A first
- Connect with device B second
- Disconnect device A
- See the message `ignoring event because handle is unknown to bleno.`
- See no `disconnect` event being triggered

This issue could also lead to congestion problems within `pushAclOutQueue()`, since `this._handleAclsInProgress[handle]` will not be cleared. It seems to be simply a leftover from when Bleno only supported a single connection at a time.

Borrowed the `this._handleAclsInProgress[handle] === undefined` check from the handling of the `EVT_NUMBER_OF_COMPLETED_PACKETS` event.

Happy to discuss or change anything you like!