### PR TITLE
fix(build): upgrade Docker API version to v1.44 and bump bluetooth-hc…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,6 @@ jobs:
         include:
           - name: darwin
             os: macos-latest
-            node: x64
             command: prebuildify
             args: --arch x64+arm64
           - name: win32-x86

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
       "dependencies": {
         "debug": "^4.4.0",
         "node-addon-api": "^8.3.1",
-        "node-gyp-build": "^4.8.4"
+        "node-gyp-build": "^4.8.4",
+        "patch-package": "^8.0.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^19.3.0",
@@ -45,7 +46,7 @@
         "node": ">=14"
       },
       "optionalDependencies": {
-        "@stoprocent/bluetooth-hci-socket": "^2.2.3"
+        "@stoprocent/bluetooth-hci-socket": "^2.2.5"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2081,9 +2082,9 @@
       }
     },
     "node_modules/@stoprocent/bluetooth-hci-socket": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@stoprocent/bluetooth-hci-socket/-/bluetooth-hci-socket-2.2.3.tgz",
-      "integrity": "sha512-aQmCkEaybqH7B1K6k2oJoZTf03g3PzmZFfi9+NHDiNVPi2Mbet4Mf86gVNEnctaG5aS9743zEMxSunWOzpt3MQ==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@stoprocent/bluetooth-hci-socket/-/bluetooth-hci-socket-2.2.5.tgz",
+      "integrity": "sha512-uP/Hflt7zRKt9W5WgMyRn4I5V3Z/PjTc28qCya6A3N99Sc1vqrQn4XRx1oYc5L/Qk7d4SRHNF0J2jWvOSVq6bw==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2392,8 +2393,7 @@
     },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
-      "license": "BSD-2-Clause",
-      "optional": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/acorn": {
       "version": "7.4.1",
@@ -2502,7 +2502,6 @@
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2736,7 +2735,6 @@
     "node_modules/at-least-node": {
       "version": "1.0.0",
       "license": "ISC",
-      "optional": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -2757,7 +2755,6 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -2843,7 +2840,6 @@
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -2852,7 +2848,6 @@
     },
     "node_modules/braces": {
       "version": "3.0.2",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.0.1"
@@ -3236,7 +3231,6 @@
     },
     "node_modules/call-bind": {
       "version": "1.0.8",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.0",
@@ -3253,7 +3247,6 @@
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3266,7 +3259,6 @@
     "node_modules/call-bound": {
       "version": "1.0.4",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
@@ -3338,7 +3330,6 @@
     },
     "node_modules/chalk": {
       "version": "4.1.2",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -3353,7 +3344,6 @@
     },
     "node_modules/chalk/node_modules/supports-color": {
       "version": "7.2.0",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -3408,7 +3398,6 @@
         }
       ],
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -3505,7 +3494,6 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3516,7 +3504,6 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/combine-source-map": {
@@ -3546,7 +3533,6 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/concat-stream": {
@@ -3828,7 +3814,6 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4051,7 +4036,6 @@
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -4363,7 +4347,6 @@
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -4736,7 +4719,6 @@
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4744,7 +4726,6 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4752,7 +4733,6 @@
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -5388,7 +5368,6 @@
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -5463,7 +5442,6 @@
     "node_modules/find-yarn-workspace-root": {
       "version": "2.0.0",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "micromatch": "^4.0.2"
       }
@@ -5623,7 +5601,6 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -5640,7 +5617,6 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5708,7 +5684,6 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -5739,7 +5714,6 @@
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -5887,7 +5861,6 @@
     },
     "node_modules/glob": {
       "version": "7.2.3",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -5917,7 +5890,6 @@
     },
     "node_modules/glob/node_modules/minimatch": {
       "version": "3.1.2",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -6019,7 +5991,6 @@
     },
     "node_modules/gopd": {
       "version": "1.2.0",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6030,7 +6001,6 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/graphemer": {
@@ -6090,7 +6060,6 @@
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6098,7 +6067,6 @@
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -6120,7 +6088,6 @@
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6211,7 +6178,6 @@
     },
     "node_modules/hasown": {
       "version": "2.0.2",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -6462,7 +6428,6 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -6471,7 +6436,6 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -6712,7 +6676,6 @@
     "node_modules/is-docker": {
       "version": "2.2.1",
       "license": "MIT",
-      "optional": true,
       "bin": {
         "is-docker": "cli.js"
       },
@@ -6788,7 +6751,6 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -6968,7 +6930,6 @@
     "node_modules/is-wsl": {
       "version": "2.2.0",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "is-docker": "^2.0.0"
       },
@@ -6983,7 +6944,6 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/issue-parser": {
@@ -7222,7 +7182,6 @@
     "node_modules/json-stable-stringify": {
       "version": "1.2.1",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.3",
@@ -7244,8 +7203,7 @@
     },
     "node_modules/json-stable-stringify/node_modules/isarray": {
       "version": "2.0.5",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -7260,7 +7218,6 @@
     },
     "node_modules/jsonfile": {
       "version": "6.1.0",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -7272,7 +7229,6 @@
     "node_modules/jsonify": {
       "version": "0.0.1",
       "license": "Public Domain",
-      "optional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -7311,7 +7267,6 @@
     "node_modules/klaw-sync": {
       "version": "6.0.0",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "graceful-fs": "^4.1.11"
       }
@@ -7653,7 +7608,6 @@
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7695,7 +7649,6 @@
     },
     "node_modules/micromatch": {
       "version": "4.0.5",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.2",
@@ -7778,7 +7731,6 @@
     },
     "node_modules/minimist": {
       "version": "1.2.8",
-      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -11372,7 +11324,6 @@
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -11443,7 +11394,6 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -11466,7 +11416,6 @@
     "node_modules/open": {
       "version": "7.4.2",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "is-docker": "^2.0.0",
         "is-wsl": "^2.1.1"
@@ -11502,7 +11451,6 @@
     "node_modules/os-tmpdir": {
       "version": "1.0.2",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11715,7 +11663,6 @@
     "node_modules/patch-package": {
       "version": "8.0.0",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@yarnpkg/lockfile": "^1.1.0",
         "chalk": "^4.1.2",
@@ -11744,7 +11691,6 @@
     "node_modules/patch-package/node_modules/fs-extra": {
       "version": "9.1.0",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
@@ -11758,7 +11704,6 @@
     "node_modules/patch-package/node_modules/rimraf": {
       "version": "2.7.1",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -11769,7 +11714,6 @@
     "node_modules/patch-package/node_modules/slash": {
       "version": "2.0.0",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -11789,7 +11733,6 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -11797,7 +11740,6 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11846,7 +11788,6 @@
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -13031,7 +12972,6 @@
     },
     "node_modules/semver": {
       "version": "7.6.3",
-      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -13131,7 +13071,6 @@
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -13181,7 +13120,6 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -13192,7 +13130,6 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -14158,7 +14095,6 @@
     "node_modules/tmp": {
       "version": "0.0.33",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "os-tmpdir": "~1.0.2"
       },
@@ -14176,7 +14112,6 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -14445,7 +14380,6 @@
     },
     "node_modules/universalify": {
       "version": "2.0.0",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
@@ -14590,7 +14524,6 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -14671,7 +14604,6 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
@@ -14704,7 +14636,6 @@
     "node_modules/yaml": {
       "version": "2.7.1",
       "license": "ISC",
-      "optional": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint \"**/*.js\"",
     "lint-fix": "eslint \"**/*.js\" --fix",
     "prebuildify": "prebuildify --napi --target 14.0.0 --force --strip --verbose",
-    "prebuildify-cross": "prebuildify-cross --napi --target 14.0.0 --force --strip --verbose",
+    "prebuildify-cross": "patch-package && prebuildify-cross --napi --target 14.0.0 --force --strip --verbose",
     "semantic-release": "semantic-release",
     "pretest": "npm run rebuild",
     "rebuild": "node-gyp rebuild",
@@ -66,11 +66,12 @@
   },
   "dependencies": {
     "debug": "^4.4.0",
+    "patch-package": "^8.0.0",
     "node-addon-api": "^8.3.1",
     "node-gyp-build": "^4.8.4"
   },
   "optionalDependencies": {
-    "@stoprocent/bluetooth-hci-socket": "^2.2.3"
+    "@stoprocent/bluetooth-hci-socket": "^2.2.5"
   },
   "publishConfig": {
     "access": "public"

--- a/patches/@thegecko+docker-run+3.1.0.patch
+++ b/patches/@thegecko+docker-run+3.1.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@thegecko/docker-run/index.js b/node_modules/@thegecko/docker-run/index.js
+index 5299bee..4de15b3 100644
+--- a/node_modules/@thegecko/docker-run/index.js
++++ b/node_modules/@thegecko/docker-run/index.js
+@@ -14,7 +14,7 @@ var endsWith = function(str, suffix) {
+ var run = function(image, opts) {
+   if (!opts) opts = {}
+ 
+-  var request = docker({host: opts.host, version: opts.version || 'v1.21'})
++  var request = docker({host: opts.host, version: opts.version || 'v1.44'})
+   var that = new events.EventEmitter()
+   var tty = !!opts.tty
+ 

--- a/patches/@vweevers+docker-pull+1.1.1.patch
+++ b/patches/@vweevers+docker-pull+1.1.1.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@vweevers/docker-pull/index.js b/node_modules/@vweevers/docker-pull/index.js
+index 67b3e73..5fcb567 100644
+--- a/node_modules/@vweevers/docker-pull/index.js
++++ b/node_modules/@vweevers/docker-pull/index.js
+@@ -12,7 +12,7 @@ var pull = function (image, opts, cb) {
+   image = parse(image)
+   if (!image) throw new Error('Invalid image')
+ 
+-  var request = docker({host: opts.host, version: opts.version || 'v1.21'})
++  var request = docker({host: opts.host, version: opts.version || 'v1.44'})
+   var that = new events.EventEmitter()
+   var layers = {}
+   var progress = {}

--- a/patches/prebuildify-cross+5.1.1.patch
+++ b/patches/prebuildify-cross+5.1.1.patch
@@ -1,0 +1,30 @@
+diff --git a/node_modules/prebuildify-cross/guest.js b/node_modules/prebuildify-cross/guest.js
+index dfd9eb7..6d284fb 100644
+--- a/node_modules/prebuildify-cross/guest.js
++++ b/node_modules/prebuildify-cross/guest.js
+@@ -9,19 +9,15 @@ const cwd = '/home/node/app'
+ const files = JSON.parse(process.env.PREBUILDIFY_CROSS_FILES)
+ const argv = process.argv.slice(2)
+ 
+-// Copy host files to working directory
+-for (const file of files) {
+-  const a = path.join('/input', file)
+-  const b = path.join(cwd, file)
++// Recursively copy all input files to working directory
++fs.cpSync('/input', cwd, { recursive: true })
+ 
+-  fs.mkdirSync(path.dirname(b), { recursive: true })
+-  fs.copyFileSync(a, b, fs.constants.COPYFILE_EXCL)
+-  fs.chmodSync(b, 0o644)
++// Clean build directory if it exists to ensure fresh build
++const buildDir = path.join(cwd, 'build')
++if (fs.existsSync(buildDir)) {
++  fs.rmSync(buildDir, { recursive: true, force: true })
+ }
+ 
+-// Use node_modules of host to avoid a second install step
+-fs.symlinkSync('/input/node_modules', path.join(cwd, 'node_modules'))
+-
+ const stdio = ['ignore', 2, 2]
+ const res = cp.spawnSync('npx', ['--no-install', 'prebuildify', ...argv], { cwd, stdio })
+ 


### PR DESCRIPTION
…i-socket

- Add patch-package patches for @thegecko/docker-run, @vweevers/docker-pull, and prebuildify-cross to fix Docker API version compatibility with modern Docker Engine (v1.21 -> v1.44)
- Replace file-by-file copy in prebuildify-cross guest with recursive fs.cpSync and add build directory cleanup
- Add patch-package to dependencies and run patches before prebuildify-cross
- Remove node x64 constraint for darwin builds (prebuildify handles cross-compilation via --arch x64+arm64)
- Bump @stoprocent/bluetooth-hci-socket from ^2.2.3 to ^2.2.5

https://claude.ai/code/session_01K7e8mTCdPQfYm6hSUGM38i