### PR TITLE
fix: prevent listener accumulation in EventEmitter subclasses

### DIFF
--- a/examples/pizza/pizza.js
+++ b/examples/pizza/pizza.js
@@ -1,6 +1,6 @@
-const NobleEventEmitter = require('../../lib/noble-event-emitter');
+const BlenoEventEmitter = require('../../lib/bleno-event-emitter');
 
-class Pizza extends NobleEventEmitter {
+class Pizza extends BlenoEventEmitter {
   constructor () {
     super();
     this.toppings = PizzaToppings.NONE;

--- a/examples/pizza/pizza.js
+++ b/examples/pizza/pizza.js
@@ -1,6 +1,6 @@
-const events = require('events');
+const NobleEventEmitter = require('../../lib/noble-event-emitter');
 
-class Pizza extends events.EventEmitter {
+class Pizza extends NobleEventEmitter {
   constructor () {
     super();
     this.toppings = PizzaToppings.NONE;

--- a/lib/bleno-event-emitter.js
+++ b/lib/bleno-event-emitter.js
@@ -1,6 +1,6 @@
 const { EventEmitter } = require('events');
 
-class NobleEventEmitter extends EventEmitter {
+class BlenoEventEmitter extends EventEmitter {
   /**
    * Like once(), but ensures at most one listener exists for the given event.
    * If a previous exclusive listener was registered for the same event, it is
@@ -24,4 +24,4 @@ class NobleEventEmitter extends EventEmitter {
   }
 }
 
-module.exports = NobleEventEmitter;
+module.exports = BlenoEventEmitter;

--- a/lib/bleno.js
+++ b/lib/bleno.js
@@ -1,13 +1,13 @@
 const debug = require('debug')('bleno');
 const UuidUtil = require('./uuid-util');
 
-const { EventEmitter } = require('events');
+const NobleEventEmitter = require('./noble-event-emitter');
 
 const PrimaryService = require('./primary-service');
 const Characteristic = require('./characteristic');
 const Descriptor = require('./descriptor');
 
-class Bleno extends EventEmitter {
+class Bleno extends NobleEventEmitter {
   constructor (bindings) {
     super();
     this.initialized = false;
@@ -138,7 +138,7 @@ class Bleno extends EventEmitter {
       }
     } else {
       if (typeof callback === 'function') {
-        this.once('advertisingStart', callback);
+        this.onceExclusive('advertisingStart', callback);
       }
 
       const undashedServiceUuids = [];
@@ -186,7 +186,7 @@ class Bleno extends EventEmitter {
       iBeaconData.writeInt8(measuredPower, uuidDataLength + 4);
 
       if (typeof callback === 'function') {
-        this.once('advertisingStart', callback);
+        this.onceExclusive('advertisingStart', callback);
       }
 
       debug('iBeacon data = ' + iBeaconData.toString('hex'));
@@ -225,7 +225,7 @@ class Bleno extends EventEmitter {
       }
     } else {
       if (typeof callback === 'function') {
-        this.once('advertisingStart', callback);
+        this.onceExclusive('advertisingStart', callback);
       }
 
       this._bindings.startAdvertisingWithEIRData(advertisementData, scanData);
@@ -243,7 +243,7 @@ class Bleno extends EventEmitter {
 
   stopAdvertising (callback) {
     if (typeof callback === 'function') {
-      this.once('advertisingStop', callback);
+      this.onceExclusive('advertisingStop', callback);
     }
     this._bindings.stopAdvertising();
   }
@@ -264,7 +264,7 @@ class Bleno extends EventEmitter {
 
   setServices (services, callback) {
     if (typeof callback === 'function') {
-      this.once('servicesSet', callback);
+      this.onceExclusive('servicesSet', callback);
     }
     this._bindings.setServices(services);
   }
@@ -303,7 +303,7 @@ class Bleno extends EventEmitter {
 
   updateRssi (callback) {
     if (typeof callback === 'function') {
-      this.once('rssiUpdate', (rssi) => callback(null, rssi));
+      this.onceExclusive('rssiUpdate', (rssi) => callback(null, rssi));
     }
 
     this._bindings.updateRssi();

--- a/lib/bleno.js
+++ b/lib/bleno.js
@@ -1,13 +1,13 @@
 const debug = require('debug')('bleno');
 const UuidUtil = require('./uuid-util');
 
-const NobleEventEmitter = require('./noble-event-emitter');
+const BlenoEventEmitter = require('./bleno-event-emitter');
 
 const PrimaryService = require('./primary-service');
 const Characteristic = require('./characteristic');
 const Descriptor = require('./descriptor');
 
-class Bleno extends NobleEventEmitter {
+class Bleno extends BlenoEventEmitter {
   constructor (bindings) {
     super();
     this.initialized = false;

--- a/lib/characteristic.js
+++ b/lib/characteristic.js
@@ -1,7 +1,7 @@
-const NobleEventEmitter = require('./noble-event-emitter');
+const BlenoEventEmitter = require('./bleno-event-emitter');
 const UuidUtil = require('./uuid-util');
 
-class Characteristic extends NobleEventEmitter {
+class Characteristic extends BlenoEventEmitter {
   constructor (options) {
     super();
 

--- a/lib/characteristic.js
+++ b/lib/characteristic.js
@@ -1,7 +1,7 @@
-const { EventEmitter } = require('events');
+const NobleEventEmitter = require('./noble-event-emitter');
 const UuidUtil = require('./uuid-util');
 
-class Characteristic extends EventEmitter {
+class Characteristic extends NobleEventEmitter {
   constructor (options) {
     super();
 

--- a/lib/hci-socket/acl-stream.js
+++ b/lib/hci-socket/acl-stream.js
@@ -1,8 +1,8 @@
-const NobleEventEmitter = require('../noble-event-emitter');
+const BlenoEventEmitter = require('../bleno-event-emitter');
 const Smp = require('./smp');
 const Mgmt = require('./mgmt');
 
-class AclStream extends NobleEventEmitter {
+class AclStream extends BlenoEventEmitter {
   constructor (hci, handle, localAddressType, localAddress, remoteAddressType, remoteAddress) {
     super();
     this._hci = hci;

--- a/lib/hci-socket/acl-stream.js
+++ b/lib/hci-socket/acl-stream.js
@@ -1,8 +1,8 @@
-const { EventEmitter } = require('events');
+const NobleEventEmitter = require('../noble-event-emitter');
 const Smp = require('./smp');
 const Mgmt = require('./mgmt');
 
-class AclStream extends EventEmitter {
+class AclStream extends NobleEventEmitter {
   constructor (hci, handle, localAddressType, localAddress, remoteAddressType, remoteAddress) {
     super();
     this._hci = hci;

--- a/lib/hci-socket/bindings.js
+++ b/lib/hci-socket/bindings.js
@@ -1,6 +1,6 @@
 const debug = require('debug')('bindings');
 
-const { EventEmitter } = require('events');
+const NobleEventEmitter = require('../noble-event-emitter');
 const os = require('os');
 
 const AclStream = require('./acl-stream');
@@ -8,7 +8,7 @@ const Hci = require('./hci');
 const Gap = require('./gap');
 const Gatt = require('./gatt');
 
-class BlenoBindings extends EventEmitter {
+class BlenoBindings extends NobleEventEmitter {
   constructor (options) {
     super();
 

--- a/lib/hci-socket/bindings.js
+++ b/lib/hci-socket/bindings.js
@@ -1,6 +1,6 @@
 const debug = require('debug')('bindings');
 
-const NobleEventEmitter = require('../noble-event-emitter');
+const BlenoEventEmitter = require('../bleno-event-emitter');
 const os = require('os');
 
 const AclStream = require('./acl-stream');
@@ -8,7 +8,7 @@ const Hci = require('./hci');
 const Gap = require('./gap');
 const Gatt = require('./gatt');
 
-class BlenoBindings extends NobleEventEmitter {
+class BlenoBindings extends BlenoEventEmitter {
   constructor (options) {
     super();
 

--- a/lib/hci-socket/gap.js
+++ b/lib/hci-socket/gap.js
@@ -1,6 +1,6 @@
 const debug = require('debug')('gap');
 
-const { EventEmitter } = require('events');
+const NobleEventEmitter = require('../noble-event-emitter');
 const os = require('os');
 
 const Hci = require('./hci');
@@ -9,7 +9,7 @@ const isLinux = (os.platform() === 'linux');
 const isIntelEdison = isLinux && (os.release().includes('edison'));
 const isYocto = isLinux && (os.release().includes('yocto'));
 
-class Gap extends EventEmitter {
+class Gap extends NobleEventEmitter {
   constructor (hci) {
     super();
 

--- a/lib/hci-socket/gap.js
+++ b/lib/hci-socket/gap.js
@@ -1,6 +1,6 @@
 const debug = require('debug')('gap');
 
-const NobleEventEmitter = require('../noble-event-emitter');
+const BlenoEventEmitter = require('../bleno-event-emitter');
 const os = require('os');
 
 const Hci = require('./hci');
@@ -9,7 +9,7 @@ const isLinux = (os.platform() === 'linux');
 const isIntelEdison = isLinux && (os.release().includes('edison'));
 const isYocto = isLinux && (os.release().includes('yocto'));
 
-class Gap extends NobleEventEmitter {
+class Gap extends BlenoEventEmitter {
   constructor (hci) {
     super();
 

--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -3,7 +3,7 @@
 
 const debug = require('debug')('gatt');
 
-const NobleEventEmitter = require('../noble-event-emitter');
+const BlenoEventEmitter = require('../bleno-event-emitter');
 const os = require('os');
 const Characteristic = require('../characteristic');
 
@@ -64,7 +64,7 @@ const ATT_ECODE_INSUFF_RESOURCES = 0x11;
 
 const ATT_CID = 0x0004;
 
-class Gatt extends NobleEventEmitter {
+class Gatt extends BlenoEventEmitter {
   constructor () {
     super();
 

--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -3,7 +3,7 @@
 
 const debug = require('debug')('gatt');
 
-const { EventEmitter } = require('events');
+const NobleEventEmitter = require('../noble-event-emitter');
 const os = require('os');
 const Characteristic = require('../characteristic');
 
@@ -64,7 +64,7 @@ const ATT_ECODE_INSUFF_RESOURCES = 0x11;
 
 const ATT_CID = 0x0004;
 
-class Gatt extends EventEmitter {
+class Gatt extends NobleEventEmitter {
   constructor () {
     super();
 

--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -1,6 +1,6 @@
 const debug = require('debug')('hci');
 
-const { EventEmitter } = require('events');
+const NobleEventEmitter = require('../noble-event-emitter');
 const { loadDriver } = require('@stoprocent/bluetooth-hci-socket');
 
 const vendorSpecific = require('./vs');
@@ -74,7 +74,7 @@ const HCI_OE_USER_ENDED_CONNECTION = 0x13;
 
 const STATUS_MAPPER = require('./hci-status');
 
-class Hci extends EventEmitter {
+class Hci extends NobleEventEmitter {
   constructor (options) {
     super();
     options = options || {};

--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -1,6 +1,6 @@
 const debug = require('debug')('hci');
 
-const NobleEventEmitter = require('../noble-event-emitter');
+const BlenoEventEmitter = require('../bleno-event-emitter');
 const { loadDriver } = require('@stoprocent/bluetooth-hci-socket');
 
 const vendorSpecific = require('./vs');
@@ -74,7 +74,7 @@ const HCI_OE_USER_ENDED_CONNECTION = 0x13;
 
 const STATUS_MAPPER = require('./hci-status');
 
-class Hci extends NobleEventEmitter {
+class Hci extends BlenoEventEmitter {
   constructor (options) {
     super();
     options = options || {};

--- a/lib/hci-socket/smp.js
+++ b/lib/hci-socket/smp.js
@@ -1,4 +1,4 @@
-const { EventEmitter } = require('events');
+const NobleEventEmitter = require('../noble-event-emitter');
 const crypto = require('./crypto');
 
 const SMP_CID = 0x0006;
@@ -13,7 +13,7 @@ const SMP_MASTER_IDENT = 0x07;
 
 const SMP_UNSPECIFIED = 0x08;
 
-class Smp extends EventEmitter {
+class Smp extends NobleEventEmitter {
 
   constructor (aclStream, mgmt, localAddressType, localAddress, remoteAddressType, remoteAddress) {
     super();

--- a/lib/hci-socket/smp.js
+++ b/lib/hci-socket/smp.js
@@ -1,4 +1,4 @@
-const NobleEventEmitter = require('../noble-event-emitter');
+const BlenoEventEmitter = require('../bleno-event-emitter');
 const crypto = require('./crypto');
 
 const SMP_CID = 0x0006;
@@ -13,7 +13,7 @@ const SMP_MASTER_IDENT = 0x07;
 
 const SMP_UNSPECIFIED = 0x08;
 
-class Smp extends NobleEventEmitter {
+class Smp extends BlenoEventEmitter {
 
   constructor (aclStream, mgmt, localAddressType, localAddress, remoteAddressType, remoteAddress) {
     super();

--- a/lib/mac/bindings.js
+++ b/lib/mac/bindings.js
@@ -1,4 +1,4 @@
-const NobleEventEmitter = require('../noble-event-emitter');
+const BlenoEventEmitter = require('../bleno-event-emitter');
 
 const { resolve } = require('path');
 const dir = resolve(__dirname, '..', '..');
@@ -6,6 +6,6 @@ const binding = require('node-gyp-build')(dir);
 
 const { BlenoMac } = binding;
 
-Object.setPrototypeOf(BlenoMac.prototype, NobleEventEmitter.prototype);
+Object.setPrototypeOf(BlenoMac.prototype, BlenoEventEmitter.prototype);
 
 module.exports = BlenoMac;

--- a/lib/mac/bindings.js
+++ b/lib/mac/bindings.js
@@ -1,4 +1,4 @@
-const { EventEmitter } = require('events');
+const NobleEventEmitter = require('../noble-event-emitter');
 
 const { resolve } = require('path');
 const dir = resolve(__dirname, '..', '..');
@@ -6,6 +6,6 @@ const binding = require('node-gyp-build')(dir);
 
 const { BlenoMac } = binding;
 
-Object.setPrototypeOf(BlenoMac.prototype, EventEmitter.prototype);
+Object.setPrototypeOf(BlenoMac.prototype, NobleEventEmitter.prototype);
 
 module.exports = BlenoMac;

--- a/lib/noble-event-emitter.js
+++ b/lib/noble-event-emitter.js
@@ -1,0 +1,27 @@
+const { EventEmitter } = require('events');
+
+class NobleEventEmitter extends EventEmitter {
+  /**
+   * Like once(), but ensures at most one listener exists for the given event.
+   * If a previous exclusive listener was registered for the same event, it is
+   * removed before the new one is added. This prevents listener accumulation
+   * when a method is called repeatedly before the event fires.
+   */
+  onceExclusive (event, callback) {
+    if (!this._exclusiveCallbacks) {
+      this._exclusiveCallbacks = new Map();
+    }
+    const prev = this._exclusiveCallbacks.get(event);
+    if (prev) {
+      this.removeListener(event, prev);
+    }
+    const wrappedCallback = (...args) => {
+      this._exclusiveCallbacks.delete(event);
+      callback(...args);
+    };
+    this._exclusiveCallbacks.set(event, wrappedCallback);
+    this.once(event, wrappedCallback);
+  }
+}
+
+module.exports = NobleEventEmitter;

--- a/lib/primary-service.js
+++ b/lib/primary-service.js
@@ -1,7 +1,7 @@
-const { EventEmitter } = require('events');
+const NobleEventEmitter = require('./noble-event-emitter');
 const UuidUtil = require('./uuid-util');
 
-class PrimaryService extends EventEmitter {
+class PrimaryService extends NobleEventEmitter {
   constructor (options) {
     super();
     this.uuid = UuidUtil.removeDashes(options.uuid);

--- a/lib/primary-service.js
+++ b/lib/primary-service.js
@@ -1,7 +1,7 @@
-const NobleEventEmitter = require('./noble-event-emitter');
+const BlenoEventEmitter = require('./bleno-event-emitter');
 const UuidUtil = require('./uuid-util');
 
-class PrimaryService extends NobleEventEmitter {
+class PrimaryService extends BlenoEventEmitter {
   constructor (options) {
     super();
     this.uuid = UuidUtil.removeDashes(options.uuid);


### PR DESCRIPTION
Add NobleEventEmitter base class with onceExclusive() method that ensures at most one listener exists for a given event, preventing memory leaks when callback-based methods are called repeatedly before the event fires.

All EventEmitter subclasses now extend NobleEventEmitter, and the this.once() calls in Bleno's callback patterns are replaced with this.onceExclusive().

https://claude.ai/code/session_01ACdNMshQv7DuLM4bAqgMZb