### PR TITLE
chore(deps): bump @stoprocent/bluetooth-hci-socket to 2.3.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,11 @@ jobs:
             command: prebuildify
             args: --arch x64+arm64
           - name: win32-x86
-            os: windows-latest
+            os: windows-2022
             node: x86
             command: prebuildify
           - name: win32-x64
-            os: windows-latest
+            os: windows-2022
             node: x64
             command: prebuildify
           - name: linux-x64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
           # arch isn't used and we have no way to use it currently
           - { os: macos-latest, arch: x64 }
           - { os: ubuntu-latest, arch: x64 }
-          - { os: windows-latest, arch: x64 }
+          - { os: windows-2022, arch: x64 }
     steps:
     - if: matrix.config.os == 'macos-latest'
       run: sudo -H pip install setuptools

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "node": ">=14"
       },
       "optionalDependencies": {
-        "@stoprocent/bluetooth-hci-socket": "^2.2.6"
+        "@stoprocent/bluetooth-hci-socket": "^2.3.0"
       }
     },
     "node_modules/@actions/core": {
@@ -2184,9 +2184,9 @@
       }
     },
     "node_modules/@stoprocent/bluetooth-hci-socket": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@stoprocent/bluetooth-hci-socket/-/bluetooth-hci-socket-2.2.6.tgz",
-      "integrity": "sha512-elKIsQe78EnxXzxfA/iuqGufD02d6t3S95eNhFaPvTJs7S3IHq2CdIHwTg3BLwae7Jw14mwK0VhWVtNtzrLyoA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@stoprocent/bluetooth-hci-socket/-/bluetooth-hci-socket-2.3.0.tgz",
+      "integrity": "sha512-xTigfmWCBqNJyPibOCS8F4dTt0LdE5zHAlpOc919ladh1Q+PjQgSGMQZoXxpK9CzZgZCmPF5f90jC0IkogwQEg==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "node-gyp-build": "^4.8.4"
   },
   "optionalDependencies": {
-    "@stoprocent/bluetooth-hci-socket": "^2.2.6"
+    "@stoprocent/bluetooth-hci-socket": "^2.3.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## What changed

- Bumped the optional `@stoprocent/bluetooth-hci-socket` dependency from `^2.2.6` to `^2.3.0`.
- Refreshed the lockfile to resolve version `2.3.0` and its published integrity metadata.
- Pinned Windows CI jobs to `windows-2022` so the Node 18/20 matrix uses a Node-gyp-compatible Visual Studio toolchain.

## Why

Keep bleno on the current HCI socket release while preserving the existing optional-dependency behavior. GitHub's `windows-latest` image now uses Visual Studio 2026, which npm's bundled Node-gyp does not recognize on the supported Node versions.

## Impact

Fresh installs now resolve `@stoprocent/bluetooth-hci-socket` 2.3.x. No public bleno API changes are included.

## Validation

- GitHub Build matrix passed, including Windows x86 and x64 prebuilds.
- GitHub Test / Lint matrix passed on Node 18 and 20 across Linux, macOS, and Windows.
- Commit-message validation passed.
- Local clean install, lint, native rebuild, and 24 tests passed.
- Verified the installed HCI socket resolves to `2.3.0`.
