### PR TITLE
feat(windows): add native GATT support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ import { withBindings } from "@stoprocent/bleno";
 
 const bleno = withBindings('default');
 const bleno = withBindings('mac');
+const bleno = withBindings('win');
 const bleno = withBindings('hci', { hciDriver: '...', bindParams: ... });
 ```
 
@@ -326,7 +327,8 @@ await bleno.setServicesAsync(services);
 #### Disconnect client
 
 ```javascript
-bleno.disconnect(); // Linux only
+bleno.disconnect(); // disconnect all active clients
+bleno.disconnect(handle); // disconnect the client for a connection handle
 ```
 
 #### Update RSSI

--- a/README.md
+++ b/README.md
@@ -196,12 +196,23 @@ Make sure you have read and write permissions on the ```/dev/usb/*``` device tha
 
 ### Windows
 
- * [node-gyp requirements for Windows](https://github.com/TooTallNate/node-gyp#installation)
-   * Python 2.7
-   * Visual Studio ([Express](https://www.visualstudio.com/en-us/products/visual-studio-express-vs.aspx))
- * [node-bluetooth-hci-socket prerequisites](https://github.com/sandeepmistry/node-bluetooth-hci-socket#windows)
-   * Compatible Bluetooth 4.0 USB adapter
-   * [WinUSB](https://msdn.microsoft.com/en-ca/library/windows/hardware/ff540196(v=vs.85).aspx) driver setup for Bluetooth 4.0 USB adapter, using [Zadig tool](http://zadig.akeo.ie/)
+The default Windows binding uses the native WinRT GATT server and the normal
+Windows Bluetooth driver. The adapter must support the Bluetooth LE peripheral
+role. Building from source requires the current [node-gyp requirements for
+Windows](https://github.com/nodejs/node-gyp#on-windows), including Python and
+the Visual Studio C++ workload with a Windows SDK.
+
+The native binding supports dynamic services and descriptors, read and write
+requests, notifications and indications, multiple subscribed clients, MTU
+updates, and connection lifecycle events. Windows chooses the advertised local
+name; WinRT does not allow an application publisher to override it. Raw EIR and
+iBeacon advertising and peer RSSI reads are not exposed by this binding. A
+server-requested disconnect closes its GATT session, while Windows retains
+control of the physical Bluetooth link.
+
+The raw HCI binding remains available explicitly with `withBindings('hci')`.
+That mode requires a compatible USB adapter using WinUSB and should not be used
+with the native binding at the same time.
 
 ## API Reference
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -11,6 +11,11 @@
             'lib/mac/binding.gyp:binding',
           ],
         }],
+        ['OS=="win"', {
+          'dependencies': [
+            'lib/win/binding.gyp:binding',
+          ],
+        }],
       ],
     },
   ],

--- a/index.d.ts
+++ b/index.d.ts
@@ -116,7 +116,7 @@ declare module '@stoprocent/bleno' {
 
         readonly state: State;
 
-        disconnect(): void;
+        disconnect(handle?: ConnectionHandle | null): void;
 
         stop(): void;
 
@@ -172,7 +172,7 @@ declare module '@stoprocent/bleno' {
         on(event: 'rssiUpdate', cb: (rssi: number) => void): this;
     }
 
-    export type BindingType = 'default' | 'hci' | 'mac';
+    export type BindingType = 'default' | 'hci' | 'mac' | 'win';
 
     export interface BaseBindingsOptions {
 
@@ -193,7 +193,11 @@ declare module '@stoprocent/bleno' {
 
     }
 
-    export type WithBindingsOptions = HciBindingsOptions | MacBindingsOptions;
+    export interface WinBindingsOptions extends BaseBindingsOptions {
+
+    }
+
+    export type WithBindingsOptions = HciBindingsOptions | MacBindingsOptions | WinBindingsOptions;
 
     export function withBindings(
         bindingType?: BindingType, 

--- a/lib/bleno.js
+++ b/lib/bleno.js
@@ -283,9 +283,8 @@ class Bleno extends BlenoEventEmitter {
 
     if (error) {
       this.emit('servicesSetError', error);
-    } else {
-      this.emit('servicesSet', error);
     }
+    this.emit('servicesSet', error);
   }
 
   disconnect (handle = null) {

--- a/lib/bleno.js
+++ b/lib/bleno.js
@@ -29,6 +29,7 @@ class Bleno extends BlenoEventEmitter {
     this._bindings.on('mtuChange', this.onMtuChange.bind(this));
     this._bindings.on('disconnect', this.onDisconnect.bind(this));
     this._bindings.on('rssiUpdate', this.onRssiUpdate.bind(this));
+    this._bindings.on('warning', this.onWarning.bind(this));
 
     this.on('newListener', (event) => {
       if (event === 'stateChange' && !this.initialized) {
@@ -43,6 +44,12 @@ class Bleno extends BlenoEventEmitter {
     debug('platform ' + platform);
 
     this.platform = platform;
+  }
+
+  onWarning (message) {
+    debug('warning ' + message);
+
+    this.emit('warning', message);
   }
 
   onStateChange (state) {
@@ -114,9 +121,9 @@ class Bleno extends BlenoEventEmitter {
       const timeout = setTimeout(() => {  
         reject(new Error('Timeout waiting for address change'));
       }, 2000);
-      this._bindings.once('addressChange', (address) => {
-        if (address === address) {
-          clearTimeout(timeout);
+      this._bindings.once('addressChange', (newAddress) => {
+        clearTimeout(timeout);
+        if (String(newAddress).toLowerCase() === String(address).toLowerCase()) {
           resolve();
         }
         else {

--- a/lib/common/include/ThreadSafeCallback.h
+++ b/lib/common/include/ThreadSafeCallback.h
@@ -25,20 +25,23 @@ public:
     void call(ArgumentFunction argFunction);
 
 private:
+    struct CallbackContext {
+        Napi::Reference<Napi::Value> receiver;
+    };
+
     // Static callback handler
     static void callJsCallback(Napi::Env env,
                              Napi::Function jsCallback,
-                             Napi::Reference<Napi::Value>* context,
+                             CallbackContext* context,
                              ArgumentFunction* argFn);
 
     // Type alias for the thread-safe function
     using ThreadSafeFunc = Napi::TypedThreadSafeFunction<
-        Napi::Reference<Napi::Value>,
+        CallbackContext,
         ArgumentFunction,
         callJsCallback>;
 
     // Member variables
-    Napi::Reference<Napi::Value> receiver_;
     ThreadSafeFunc threadSafeFunction_;
 };
 
@@ -57,22 +60,31 @@ inline ThreadSafeCallback::ThreadSafeCallback(
             "Callback must be a function");
     }
 
-    receiver_ = Napi::Persistent(receiver);
-    threadSafeFunction_ = ThreadSafeFunc::New(
-        jsCallback.Env(),
-        jsCallback,
-        "ThreadSafeCallback callback",
-        0, 1,
-        &receiver_);
+    auto* context = new CallbackContext();
+    context->receiver = Napi::Persistent(receiver);
+    try {
+        threadSafeFunction_ = ThreadSafeFunc::New(
+            jsCallback.Env(),
+            jsCallback,
+            "ThreadSafeCallback callback",
+            0, 1,
+            context,
+            [](Napi::Env, void*, CallbackContext* callbackContext) {
+                delete callbackContext;
+            });
+    } catch (...) {
+        delete context;
+        throw;
+    }
 }
 
 inline ThreadSafeCallback::~ThreadSafeCallback() {
-    threadSafeFunction_.Abort();
+    threadSafeFunction_.Release();
 }
 
 inline void ThreadSafeCallback::call(ArgumentFunction argFunction) {
     auto argFn = new ArgumentFunction(argFunction);
-    if (threadSafeFunction_.BlockingCall(argFn) != napi_ok) {
+    if (threadSafeFunction_.NonBlockingCall(argFn) != napi_ok) {
         delete argFn;
     }
 }
@@ -80,16 +92,18 @@ inline void ThreadSafeCallback::call(ArgumentFunction argFunction) {
 inline void ThreadSafeCallback::callJsCallback(
     Napi::Env env,
     Napi::Function jsCallback,
-    Napi::Reference<Napi::Value>* context,
+    CallbackContext* context,
     ArgumentFunction* argFn) {
-    
-    if (argFn != nullptr) {
-        ArgumentVector args;
-        (*argFn)(env, args);
-        delete argFn;
 
-        if (env != nullptr && jsCallback != nullptr) {
-            jsCallback.Call(context->Value(), args);
-        }
+    std::unique_ptr<ArgumentFunction> argumentFunction(argFn);
+    if (argumentFunction == nullptr ||
+        env == nullptr ||
+        jsCallback == nullptr ||
+        context == nullptr) {
+        return;
     }
+
+    ArgumentVector args;
+    (*argumentFunction)(env, args);
+    jsCallback.Call(context->receiver.Value(), args);
 }

--- a/lib/resolve-bindings.js
+++ b/lib/resolve-bindings.js
@@ -9,6 +9,8 @@ function loadBindings (bindingType = null, options = {}) {
       return new (require('./hci-socket/bindings'))(options);
     case 'mac':
       return new (require('./mac/bindings'))(options);
+    case 'win':
+      return new (require('./win/bindings'))(options);
     default:
       throw new Error('Unsupported binding type: ' + bindingType);
   }
@@ -19,7 +21,6 @@ function getDefaultBindings (options = {}) {
   if (
     platform === 'linux' ||
     platform === 'freebsd' || 
-    platform === 'win32' ||
     platform === 'android' ||
     process.env.BLUETOOTH_HCI_SOCKET_UART_PORT ||
     process.env.BLUETOOTH_HCI_SOCKET_FORCE_UART
@@ -27,6 +28,8 @@ function getDefaultBindings (options = {}) {
     return loadBindings('hci', options);
   } else if (platform === 'darwin') {
     return loadBindings('mac', options);
+  } else if (platform === 'win32') {
+    return loadBindings('win', options);
   } else {
     throw new Error('Unsupported platform ' + platform);
   }

--- a/lib/win/binding.gyp
+++ b/lib/win/binding.gyp
@@ -1,0 +1,42 @@
+{
+  'variables': {
+    'openssl_fips': ''
+  },
+  'targets': [
+    {
+      'target_name': 'binding',
+      'sources': [
+        'src/bleno_winrt.cc',
+        'src/callbacks.cc',
+        'src/radio_watcher.cc',
+        'src/winrt_cpp.cc',
+      ],
+      'include_dirs': [
+        "<!(node -p \"require('node-addon-api').include_dir\")",
+        '../common/include',
+      ],
+      'defines': [
+        'NAPI_CPP_EXCEPTIONS',
+        'NOMINMAX',
+        'WIN32_LEAN_AND_MEAN',
+      ],
+      'libraries': [
+        'windowsapp.lib',
+      ],
+      'cflags!': [ '-fno-exceptions' ],
+      'cflags_cc!': [ '-fno-exceptions' ],
+      'msvs_settings': {
+        'VCCLCompilerTool': {
+          'ExceptionHandling': 1,
+          'AdditionalOptions': [
+            '/await',
+            '/permissive-',
+            '/std:c++17',
+          ],
+        },
+      },
+      'msvs_target_platform_version': '10.0',
+      'msvs_target_platform_minversion': '10.0.17763.0',
+    },
+  ],
+}

--- a/lib/win/bindings.js
+++ b/lib/win/bindings.js
@@ -1,0 +1,11 @@
+const BlenoEventEmitter = require('../bleno-event-emitter');
+
+const { resolve } = require('path');
+const dir = resolve(__dirname, '..', '..');
+const binding = require('node-gyp-build')(dir);
+
+const { BlenoWinRT } = binding;
+
+Object.setPrototypeOf(BlenoWinRT.prototype, BlenoEventEmitter.prototype);
+
+module.exports = BlenoWinRT;

--- a/lib/win/src/bleno_winrt.cc
+++ b/lib/win/src/bleno_winrt.cc
@@ -211,7 +211,9 @@ winrt::fire_and_forget NotifyClient(
 
 BLEPeripheralManager::BLEPeripheralManager(
     const Napi::Value& receiver,
-    const Napi::Function& callback) {
+    const Napi::Function& callback,
+    bool extendedAdvertising)
+    : mExtendedAdvertising(extendedAdvertising) {
     mEmit.Wrap(receiver, callback);
 }
 
@@ -428,6 +430,22 @@ void BLEPeripheralManager::StartProviders() {
     GattServiceProviderAdvertisingParameters parameters;
     parameters.IsDiscoverable(true);
     parameters.IsConnectable(true);
+    if (mExtendedAdvertising) {
+        // Requesting a secondary PHY switches Windows from legacy to extended
+        // advertising. Some Bluetooth 5 controllers only advertise reliably in
+        // extended mode, even though the legacy request is accepted and the
+        // provider still reports Started.
+        if (auto extended =
+                parameters.try_as<IGattServiceProviderAdvertisingParameters3>()) {
+            extended.UseLowEnergyUncoded1MPhyAsSecondaryPhy(true);
+        } else if (!mWarnedAboutExtended) {
+            mWarnedAboutExtended = true;
+            mEmit.Warning(
+                "Extended advertising was requested but this version of Windows "
+                "does not expose the secondary PHY parameters; falling back to "
+                "legacy advertising.");
+        }
+    }
     for (auto& context : mProviders) {
         const auto status = context.provider.AdvertisementStatus();
         if (status != GattServiceProviderAdvertisementStatus::Started &&
@@ -714,6 +732,16 @@ void BLEPeripheralManager::Stop() noexcept {
 
 BlenoWinRT::BlenoWinRT(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<BlenoWinRT>(info) {
+    if (info.Length() > 0 && info[0].IsObject()) {
+        auto options = info[0].As<Napi::Object>();
+        auto value = options.Get("extendedAdvertising");
+        if (!value.IsUndefined() && !value.IsNull()) {
+            mExtendedAdvertising = value.ToBoolean();
+        }
+    }
+    if (GetEnvironmentVariableA("BLENO_WIN_EXTENDED_ADV", nullptr, 0) != 0) {
+        mExtendedAdvertising = true;
+    }
 }
 
 BlenoWinRT::~BlenoWinRT() {
@@ -746,7 +774,8 @@ Napi::Value BlenoWinRT::Init(const Napi::CallbackInfo& info) {
 
     mPeripheralManager = std::make_unique<BLEPeripheralManager>(
         receiver,
-        emit.As<Napi::Function>());
+        emit.As<Napi::Function>(),
+        mExtendedAdvertising);
     mPeripheralManager->Start();
     return info.Env().Undefined();
 }

--- a/lib/win/src/bleno_winrt.cc
+++ b/lib/win/src/bleno_winrt.cc
@@ -62,6 +62,53 @@ std::string BluetoothErrorMessage(const std::string& operation, BluetoothError e
         std::to_string(static_cast<int32_t>(error));
 }
 
+// Resolves the 16-bit SIG alias of a UUID built on the Bluetooth base UUID
+// (0000xxxx-0000-1000-8000-00805F9B34FB), so short ('2902') and long forms
+// are both recognised.
+bool TryGetBluetoothAlias(const winrt::guid& uuid, uint16_t& alias) {
+    constexpr uint8_t base[8] = { 0x80, 0x00, 0x00, 0x80, 0x5F, 0x9B, 0x34, 0xFB };
+    if (uuid.Data2 != 0x0000 || uuid.Data3 != 0x1000) {
+        return false;
+    }
+    for (size_t index = 0; index < 8; ++index) {
+        if (uuid.Data4[index] != base[index]) {
+            return false;
+        }
+    }
+    if ((uuid.Data1 & 0xFFFF0000u) != 0) {
+        return false;
+    }
+    alias = static_cast<uint16_t>(uuid.Data1 & 0xFFFFu);
+    return true;
+}
+
+// Descriptors Windows publishes itself; creating them explicitly fails with
+// "The provided descriptor uuid is reserved and will be automatically
+// published by the system."
+bool IsSystemManagedDescriptor(uint16_t alias) {
+    return alias == 0x2900 ||  // Characteristic Extended Properties
+        alias == 0x2902 ||     // Client Characteristic Configuration
+        alias == 0x2903;       // Server Characteristic Configuration
+}
+
+// 0x2904 Characteristic Presentation Format is also reserved, but Windows
+// accepts its contents through GattLocalCharacteristicParameters, so the
+// declared value is preserved rather than dropped.
+bool TryParsePresentationFormat(const Data& value, GattPresentationFormat& format) {
+    if (value.size() < 7) {
+        return false;
+    }
+    const auto unit = static_cast<uint16_t>(value[2] | (value[3] << 8));
+    const auto description = static_cast<uint16_t>(value[5] | (value[6] << 8));
+    format = GattPresentationFormat::FromParts(
+        value[0],
+        static_cast<int32_t>(static_cast<int8_t>(value[1])),
+        unit,
+        value[4],
+        description);
+    return true;
+}
+
 std::vector<ServiceDefinition> ParseServices(const Napi::Array& services) {
     std::vector<ServiceDefinition> result;
     result.reserve(services.Length());
@@ -120,13 +167,23 @@ std::vector<ServiceDefinition> ParseServices(const Napi::Array& services) {
                     descriptorObject.Get("uuid").ToString().Utf8Value();
                 const auto descriptorValue = FromNapiValue(descriptorObject.Get("value"));
 
-                if (descriptorUuid == "2901") {
+                const auto descriptorGuid = ToGuid(descriptorUuid);
+                uint16_t alias = 0;
+                const bool isSigDescriptor =
+                    TryGetBluetoothAlias(descriptorGuid, alias);
+
+                if (isSigDescriptor && alias == 0x2901) {
                     characteristic.userDescription = std::string(
                         descriptorValue.begin(),
                         descriptorValue.end());
-                } else if (descriptorUuid != "2902") {
+                } else if (isSigDescriptor && alias == 0x2904) {
+                    GattPresentationFormat format{ nullptr };
+                    if (TryParsePresentationFormat(descriptorValue, format)) {
+                        characteristic.presentationFormats.push_back(format);
+                    }
+                } else if (!isSigDescriptor || !IsSystemManagedDescriptor(alias)) {
                     characteristic.descriptors.push_back({
-                        ToGuid(descriptorUuid),
+                        descriptorGuid,
                         descriptorValue,
                     });
                 }
@@ -191,6 +248,16 @@ void BLEPeripheralManager::StartAdvertising(
     mAdvertisedServiceUuids = serviceUuids;
     try {
         mAdvertising = true;
+        // GattServiceProviderAdvertisingParameters exposes no local name: Windows
+        // always advertises the system Bluetooth name. Say so instead of silently
+        // ignoring the caller's name.
+        if (!mName.empty() && !mWarnedAboutName) {
+            mWarnedAboutName = true;
+            mEmit.Warning(
+                "The native Windows binding cannot set the advertised local name; "
+                "Windows advertises the system Bluetooth name instead. Discover this "
+                "peripheral by its service UUID rather than by the name '" + mName + "'.");
+        }
         StartProviders();
         mEmit.AdvertisingStart();
     } catch (const winrt::hresult_error& error) {
@@ -251,7 +318,11 @@ void BLEPeripheralManager::SetServices(
             providerContext.advertisementStatusChanged =
                 providerContext.provider.AdvertisementStatusChanged(
                     [this](const auto&, const auto& args) {
+                        // Windows briefly reports Aborted with BluetoothError::Success
+                        // while the provider re-tunes its advertisement during startup.
+                        // Only surface a genuine failure.
                         if (args.Status() == GattServiceProviderAdvertisementStatus::Aborted &&
+                            args.Error() != BluetoothError::Success &&
                             !mStopped) {
                             mEmit.AdvertisingStart(BluetoothErrorMessage(
                                 "Advertising GATT service",
@@ -273,6 +344,9 @@ void BLEPeripheralManager::SetServices(
                 if (!definition.userDescription.empty()) {
                     parameters.UserDescription(
                         winrt::to_hstring(definition.userDescription));
+                }
+                for (const auto& format : definition.presentationFormats) {
+                    parameters.PresentationFormats().Append(format);
                 }
 
                 auto characteristicResult =

--- a/lib/win/src/bleno_winrt.cc
+++ b/lib/win/src/bleno_winrt.cc
@@ -1,0 +1,812 @@
+#include "bleno_winrt.h"
+
+#include <algorithm>
+#include <stdexcept>
+#include <utility>
+
+#include <windows.h>
+#include <winrt/Windows.Storage.Streams.h>
+
+#include "winrt_cpp.h"
+
+using winrt::Windows::Devices::Bluetooth::BluetoothError;
+using namespace winrt::Windows::Devices::Bluetooth::GenericAttributeProfile;
+
+namespace {
+
+constexpr uint16_t ResultSuccess = 0x00;
+
+bool ArrayContains(const Napi::Array& values, const char* expected) {
+    for (uint32_t index = 0; index < values.Length(); ++index) {
+        if (values.Get(index).ToString().Utf8Value() == expected) {
+            return true;
+        }
+    }
+    return false;
+}
+
+GattCharacteristicProperties ParseProperties(const Napi::Array& properties) {
+    auto result = static_cast<GattCharacteristicProperties>(0);
+    for (uint32_t index = 0; index < properties.Length(); ++index) {
+        const auto property = properties.Get(index).ToString().Utf8Value();
+        if (property == "broadcast") {
+            throw std::invalid_argument(
+                "Windows GATT server does not support the broadcast characteristic property");
+        } else if (property == "read") {
+            result |= GattCharacteristicProperties::Read;
+        } else if (property == "write") {
+            result |= GattCharacteristicProperties::Write;
+        } else if (property == "writeWithoutResponse") {
+            result |= GattCharacteristicProperties::WriteWithoutResponse;
+        } else if (property == "notify") {
+            result |= GattCharacteristicProperties::Notify;
+        } else if (property == "indicate") {
+            result |= GattCharacteristicProperties::Indicate;
+        } else if (property == "authenticatedSignedWrites") {
+            result |= GattCharacteristicProperties::AuthenticatedSignedWrites;
+        } else if (property == "extendedProperties") {
+            result |= GattCharacteristicProperties::ExtendedProperties;
+        } else {
+            throw std::invalid_argument("Unsupported characteristic property: " + property);
+        }
+    }
+    return result;
+}
+
+bool HasProperty(GattCharacteristicProperties properties, GattCharacteristicProperties value) {
+    return (properties & value) == value;
+}
+
+std::string BluetoothErrorMessage(const std::string& operation, BluetoothError error) {
+    return operation + " failed with Bluetooth error " +
+        std::to_string(static_cast<int32_t>(error));
+}
+
+std::vector<ServiceDefinition> ParseServices(const Napi::Array& services) {
+    std::vector<ServiceDefinition> result;
+    result.reserve(services.Length());
+
+    for (uint32_t serviceIndex = 0; serviceIndex < services.Length(); ++serviceIndex) {
+        auto serviceObject = services.Get(serviceIndex).As<Napi::Object>();
+        ServiceDefinition service{
+            ToGuid(serviceObject.Get("uuid").ToString().Utf8Value()),
+            {},
+        };
+
+        auto characteristics = serviceObject.Get("characteristics").As<Napi::Array>();
+        service.characteristics.reserve(characteristics.Length());
+        for (uint32_t characteristicIndex = 0;
+             characteristicIndex < characteristics.Length();
+             ++characteristicIndex) {
+            auto characteristicObject =
+                characteristics.Get(characteristicIndex).As<Napi::Object>();
+            auto properties =
+                characteristicObject.Get("properties").As<Napi::Array>();
+            auto secure = characteristicObject.Get("secure").As<Napi::Array>();
+
+            CharacteristicDefinition characteristic{
+                ToGuid(characteristicObject.Get("uuid").ToString().Utf8Value()),
+                ParseProperties(properties),
+                ArrayContains(secure, "read")
+                    ? GattProtectionLevel::EncryptionRequired
+                    : GattProtectionLevel::Plain,
+                ArrayContains(secure, "write") ||
+                        ArrayContains(secure, "writeWithoutResponse")
+                    ? GattProtectionLevel::EncryptionRequired
+                    : GattProtectionLevel::Plain,
+            };
+
+            const auto value = characteristicObject.Get("value");
+            if (!value.IsNull() && !value.IsUndefined()) {
+                characteristic.hasStaticValue = true;
+                characteristic.staticValue = FromNapiValue(value);
+            }
+
+            auto emit = characteristicObject.Get("emit");
+            if (!emit.IsFunction()) {
+                throw std::invalid_argument("Characteristic is missing its emit function");
+            }
+            characteristic.emitter = std::make_shared<EmitCharacteristic>();
+            characteristic.emitter->Wrap(
+                characteristicObject,
+                emit.As<Napi::Function>());
+
+            auto descriptors = characteristicObject.Get("descriptors").As<Napi::Array>();
+            for (uint32_t descriptorIndex = 0;
+                 descriptorIndex < descriptors.Length();
+                 ++descriptorIndex) {
+                auto descriptorObject = descriptors.Get(descriptorIndex).As<Napi::Object>();
+                const auto descriptorUuid =
+                    descriptorObject.Get("uuid").ToString().Utf8Value();
+                const auto descriptorValue = FromNapiValue(descriptorObject.Get("value"));
+
+                if (descriptorUuid == "2901") {
+                    characteristic.userDescription = std::string(
+                        descriptorValue.begin(),
+                        descriptorValue.end());
+                } else if (descriptorUuid != "2902") {
+                    characteristic.descriptors.push_back({
+                        ToGuid(descriptorUuid),
+                        descriptorValue,
+                    });
+                }
+            }
+
+            service.characteristics.push_back(std::move(characteristic));
+        }
+        result.push_back(std::move(service));
+    }
+    return result;
+}
+
+winrt::fire_and_forget NotifyClient(
+    GattLocalCharacteristic characteristic,
+    GattSubscribedClient client,
+    Data data) {
+    try {
+        co_await characteristic.NotifyValueAsync(ToBuffer(data), client);
+    } catch (...) {
+        // The client may have unsubscribed between the JS callback and this send.
+    }
+}
+
+}  // namespace
+
+BLEPeripheralManager::BLEPeripheralManager(
+    const Napi::Value& receiver,
+    const Napi::Function& callback) {
+    mEmit.Wrap(receiver, callback);
+}
+
+BLEPeripheralManager::~BLEPeripheralManager() {
+    Stop();
+}
+
+void BLEPeripheralManager::Start() {
+    std::lock_guard<std::recursive_mutex> lock(mMutex);
+    if (mStopped) {
+        return;
+    }
+
+    mEmit.Platform("win32");
+    mWatcher.Start([this](AdapterState state) {
+        std::lock_guard<std::recursive_mutex> callbackLock(mMutex);
+        if (mStopped || state == mRadioState) {
+            return;
+        }
+        mRadioState = state;
+        mEmit.StateChange(AdapterStateToString(state));
+    });
+}
+
+void BLEPeripheralManager::StartAdvertising(
+    const std::string& name,
+    const std::vector<winrt::guid>& serviceUuids) {
+    std::lock_guard<std::recursive_mutex> lock(mMutex);
+    if (mStopped) {
+        return;
+    }
+
+    mName = name;
+    mAdvertisedServiceUuids = serviceUuids;
+    try {
+        mAdvertising = true;
+        StartProviders();
+        mEmit.AdvertisingStart();
+    } catch (const winrt::hresult_error& error) {
+        mAdvertising = false;
+        mEmit.AdvertisingStart(HResultMessage(error));
+    } catch (const std::exception& error) {
+        mAdvertising = false;
+        mEmit.AdvertisingStart(error.what());
+    }
+}
+
+void BLEPeripheralManager::ReportUnsupportedAdvertising(
+    const std::string& feature) {
+    mEmit.AdvertisingStart(
+        feature + " is not supported by the native Windows binding");
+}
+
+void BLEPeripheralManager::StopAdvertising() {
+    std::lock_guard<std::recursive_mutex> lock(mMutex);
+    for (auto& context : mProviders) {
+        try {
+            if (context.provider) {
+                const auto status = context.provider.AdvertisementStatus();
+                if (status != GattServiceProviderAdvertisementStatus::Created &&
+                    status != GattServiceProviderAdvertisementStatus::Stopped) {
+                    context.provider.StopAdvertising();
+                }
+            }
+        } catch (...) {
+        }
+    }
+    mAdvertising = false;
+    if (!mStopped) {
+        mEmit.AdvertisingStop();
+    }
+}
+
+void BLEPeripheralManager::SetServices(
+    const std::vector<ServiceDefinition>& services) {
+    std::lock_guard<std::recursive_mutex> lock(mMutex);
+    if (mStopped) {
+        return;
+    }
+
+    ClearProviders();
+    try {
+        for (const auto& service : services) {
+            auto providerResult = GattServiceProvider::CreateAsync(service.uuid).get();
+            if (providerResult.Error() != BluetoothError::Success ||
+                !providerResult.ServiceProvider()) {
+                throw std::runtime_error(BluetoothErrorMessage(
+                    "Creating GATT service",
+                    providerResult.Error()));
+            }
+
+            ProviderContext providerContext;
+            providerContext.provider = providerResult.ServiceProvider();
+            providerContext.advertisementStatusChanged =
+                providerContext.provider.AdvertisementStatusChanged(
+                    [this](const auto&, const auto& args) {
+                        if (args.Status() == GattServiceProviderAdvertisementStatus::Aborted &&
+                            !mStopped) {
+                            mEmit.AdvertisingStart(BluetoothErrorMessage(
+                                "Advertising GATT service",
+                                args.Error()));
+                        }
+                    });
+            providerContext.hasAdvertisementStatusChanged = true;
+            mProviders.push_back(std::move(providerContext));
+            auto& activeProvider = mProviders.back();
+
+            for (const auto& definition : service.characteristics) {
+                GattLocalCharacteristicParameters parameters;
+                parameters.CharacteristicProperties(definition.properties);
+                parameters.ReadProtectionLevel(definition.readProtection);
+                parameters.WriteProtectionLevel(definition.writeProtection);
+                if (definition.hasStaticValue) {
+                    parameters.StaticValue(ToBuffer(definition.staticValue));
+                }
+                if (!definition.userDescription.empty()) {
+                    parameters.UserDescription(
+                        winrt::to_hstring(definition.userDescription));
+                }
+
+                auto characteristicResult =
+                    activeProvider.provider.Service()
+                        .CreateCharacteristicAsync(definition.uuid, parameters)
+                        .get();
+                if (characteristicResult.Error() != BluetoothError::Success ||
+                    !characteristicResult.Characteristic()) {
+                    throw std::runtime_error(BluetoothErrorMessage(
+                        "Creating GATT characteristic",
+                        characteristicResult.Error()));
+                }
+
+                auto context = std::make_shared<CharacteristicContext>();
+                context->characteristic = characteristicResult.Characteristic();
+                context->emitter = definition.emitter;
+                mCharacteristics.push_back(context);
+
+                if (!definition.hasStaticValue &&
+                    HasProperty(definition.properties, GattCharacteristicProperties::Read)) {
+                    context->readRequested = context->characteristic.ReadRequested(
+                        [this, context](const auto&, const auto& args) {
+                            HandleRead(context, args);
+                        });
+                    context->hasReadRequested = true;
+                }
+
+                if (HasProperty(definition.properties, GattCharacteristicProperties::Write) ||
+                    HasProperty(
+                        definition.properties,
+                        GattCharacteristicProperties::WriteWithoutResponse)) {
+                    context->writeRequested = context->characteristic.WriteRequested(
+                        [this, context](const auto&, const auto& args) {
+                            HandleWrite(context, args);
+                        });
+                    context->hasWriteRequested = true;
+                }
+
+                if (HasProperty(definition.properties, GattCharacteristicProperties::Notify) ||
+                    HasProperty(definition.properties, GattCharacteristicProperties::Indicate)) {
+                    context->subscribedClientsChanged =
+                        context->characteristic.SubscribedClientsChanged(
+                            [this, context](const auto&, const auto&) {
+                                HandleSubscribersChanged(context);
+                            });
+                    context->hasSubscribedClientsChanged = true;
+                }
+
+                for (const auto& descriptor : definition.descriptors) {
+                    GattLocalDescriptorParameters descriptorParameters;
+                    descriptorParameters.ReadProtectionLevel(GattProtectionLevel::Plain);
+                    descriptorParameters.StaticValue(ToBuffer(descriptor.value));
+                    auto descriptorResult = context->characteristic
+                        .CreateDescriptorAsync(descriptor.uuid, descriptorParameters)
+                        .get();
+                    if (descriptorResult.Error() != BluetoothError::Success) {
+                        throw std::runtime_error(BluetoothErrorMessage(
+                            "Creating GATT descriptor",
+                            descriptorResult.Error()));
+                    }
+                }
+            }
+        }
+
+        if (mAdvertising) {
+            StartProviders();
+        }
+        mEmit.ServicesSet();
+    } catch (const winrt::hresult_error& error) {
+        ClearProviders();
+        mEmit.ServicesSet(HResultMessage(error));
+    } catch (const std::exception& error) {
+        ClearProviders();
+        mEmit.ServicesSet(error.what());
+    }
+}
+
+void BLEPeripheralManager::StartProviders() {
+    GattServiceProviderAdvertisingParameters parameters;
+    parameters.IsDiscoverable(true);
+    parameters.IsConnectable(true);
+    for (auto& context : mProviders) {
+        const auto status = context.provider.AdvertisementStatus();
+        if (status != GattServiceProviderAdvertisementStatus::Started &&
+            status != GattServiceProviderAdvertisementStatus::StartedWithoutAllAdvertisementData) {
+            context.provider.StartAdvertising(parameters);
+        }
+    }
+}
+
+void BLEPeripheralManager::ClearProviders() noexcept {
+    for (const auto& context : mCharacteristics) {
+        for (const auto& subscriber : context->subscribers) {
+            try {
+                context->emitter->Unsubscribe(subscriber.first);
+            } catch (...) {
+            }
+        }
+        UnregisterCharacteristic(context);
+    }
+    for (auto& context : mProviders) {
+        try {
+            if (context.provider) {
+                if (context.hasAdvertisementStatusChanged) {
+                    context.provider.AdvertisementStatusChanged(
+                        context.advertisementStatusChanged);
+                }
+                const auto status = context.provider.AdvertisementStatus();
+                if (status != GattServiceProviderAdvertisementStatus::Created &&
+                    status != GattServiceProviderAdvertisementStatus::Stopped) {
+                    context.provider.StopAdvertising();
+                }
+            }
+        } catch (...) {
+        }
+    }
+    mCharacteristics.clear();
+    mProviders.clear();
+}
+
+void BLEPeripheralManager::EnsureSession(const GattSession& session) {
+    if (!session) {
+        return;
+    }
+
+    const auto connection = ToConnectionId(session);
+    bool isNew = false;
+    {
+        std::lock_guard<std::recursive_mutex> lock(mMutex);
+        if (mStopped || mSessions.find(connection) != mSessions.end()) {
+            return;
+        }
+
+        auto context = std::make_shared<SessionContext>();
+        context->session = session;
+        context->statusChanged = session.SessionStatusChanged(
+            [this, connection](const auto&, const auto& args) {
+                if (args.Status() == GattSessionStatus::Closed) {
+                    HandleSessionClosed(connection);
+                }
+            });
+        context->hasStatusChanged = true;
+        context->maxPduSizeChanged = session.MaxPduSizeChanged(
+            [this](const auto& sender, const auto&) {
+                if (!mStopped) {
+                    mEmit.MtuChange(sender.MaxPduSize());
+                }
+            });
+        context->hasMaxPduSizeChanged = true;
+        mSessions.emplace(connection, std::move(context));
+        isNew = true;
+    }
+
+    if (isNew) {
+        mEmit.Accept(connection);
+        mEmit.MtuChange(session.MaxPduSize());
+    }
+}
+
+void BLEPeripheralManager::HandleSessionClosed(
+    const std::string& connection) noexcept {
+    try {
+        std::lock_guard<std::recursive_mutex> lock(mMutex);
+        auto session = mSessions.find(connection);
+        if (mStopped || session == mSessions.end()) {
+            return;
+        }
+
+        if (session->second->hasStatusChanged) {
+            session->second->session.SessionStatusChanged(
+                session->second->statusChanged);
+        }
+        if (session->second->hasMaxPduSizeChanged) {
+            session->second->session.MaxPduSizeChanged(
+                session->second->maxPduSizeChanged);
+        }
+        mSessions.erase(session);
+
+        for (const auto& context : mCharacteristics) {
+            if (context->subscribers.erase(connection) > 0) {
+                context->emitter->Unsubscribe(connection);
+            }
+        }
+        mEmit.Disconnect(connection);
+    } catch (...) {
+    }
+}
+
+void BLEPeripheralManager::HandleRead(
+    const std::shared_ptr<CharacteristicContext>& context,
+    const GattReadRequestedEventArgs& args) {
+    auto deferral = args.GetDeferral();
+    try {
+        auto request = args.GetRequestAsync().get();
+        if (!request) {
+            deferral.Complete();
+            return;
+        }
+
+        EnsureSession(args.Session());
+        const auto connection = ToConnectionId(args.Session());
+        context->emitter->ReadRequest(
+            connection,
+            static_cast<uint16_t>(request.Offset()),
+            [request, deferral](uint16_t result, const Data& data) {
+                try {
+                    if (result == ResultSuccess) {
+                        request.RespondWithValue(ToBuffer(data));
+                    } else {
+                        request.RespondWithProtocolError(static_cast<uint8_t>(result));
+                    }
+                } catch (...) {
+                }
+                deferral.Complete();
+            });
+    } catch (...) {
+        deferral.Complete();
+    }
+}
+
+void BLEPeripheralManager::HandleWrite(
+    const std::shared_ptr<CharacteristicContext>& context,
+    const GattWriteRequestedEventArgs& args) {
+    auto deferral = args.GetDeferral();
+    try {
+        auto request = args.GetRequestAsync().get();
+        if (!request) {
+            deferral.Complete();
+            return;
+        }
+
+        EnsureSession(args.Session());
+        const auto connection = ToConnectionId(args.Session());
+        const bool withoutResponse =
+            request.Option() != GattWriteOption::WriteWithResponse;
+        context->emitter->WriteRequest(
+            connection,
+            FromBuffer(request.Value()),
+            static_cast<uint16_t>(request.Offset()),
+            withoutResponse,
+            [request, deferral, withoutResponse](uint16_t result) {
+                try {
+                    if (!withoutResponse) {
+                        if (result == ResultSuccess) {
+                            request.Respond();
+                        } else {
+                            request.RespondWithProtocolError(
+                                static_cast<uint8_t>(result));
+                        }
+                    }
+                } catch (...) {
+                }
+                deferral.Complete();
+            });
+    } catch (...) {
+        deferral.Complete();
+    }
+}
+
+void BLEPeripheralManager::HandleSubscribersChanged(
+    const std::shared_ptr<CharacteristicContext>& context) noexcept {
+    try {
+        std::lock_guard<std::recursive_mutex> lock(mMutex);
+        if (mStopped) {
+            return;
+        }
+
+        std::map<std::string, GattSubscribedClient> current;
+        for (const auto& client : context->characteristic.SubscribedClients()) {
+            auto session = client.Session();
+            EnsureSession(session);
+            current.emplace(ToConnectionId(session), client);
+        }
+
+        for (const auto& subscriber : context->subscribers) {
+            if (current.find(subscriber.first) == current.end()) {
+                context->emitter->Unsubscribe(subscriber.first);
+            }
+        }
+
+        for (const auto& subscriber : current) {
+            if (context->subscribers.find(subscriber.first) ==
+                context->subscribers.end()) {
+                auto characteristic = context->characteristic;
+                auto client = subscriber.second;
+                context->emitter->Subscribe(
+                    subscriber.first,
+                    static_cast<uint16_t>(
+                        std::max<uint16_t>(client.Session().MaxPduSize(), 3) - 3),
+                    [characteristic, client](const Data& data) {
+                        NotifyClient(characteristic, client, data);
+                    });
+            }
+        }
+        context->subscribers = std::move(current);
+    } catch (...) {
+    }
+}
+
+void BLEPeripheralManager::UnregisterCharacteristic(
+    const std::shared_ptr<CharacteristicContext>& context) noexcept {
+    if (!context->characteristic) {
+        return;
+    }
+    try {
+        if (context->hasReadRequested) {
+            context->characteristic.ReadRequested(context->readRequested);
+        }
+        if (context->hasWriteRequested) {
+            context->characteristic.WriteRequested(context->writeRequested);
+        }
+        if (context->hasSubscribedClientsChanged) {
+            context->characteristic.SubscribedClientsChanged(
+                context->subscribedClientsChanged);
+        }
+    } catch (...) {
+    }
+}
+
+void BLEPeripheralManager::Disconnect(const std::string& connection) {
+    std::vector<GattSession> sessions;
+    {
+        std::lock_guard<std::recursive_mutex> lock(mMutex);
+        for (const auto& entry : mSessions) {
+            if (connection.empty() || entry.first == connection) {
+                sessions.push_back(entry.second->session);
+            }
+        }
+    }
+    for (const auto& session : sessions) {
+        try {
+            session.MaintainConnection(false);
+            session.Close();
+        } catch (...) {
+        }
+    }
+}
+
+void BLEPeripheralManager::Stop() noexcept {
+    std::lock_guard<std::recursive_mutex> lock(mMutex);
+    if (mStopped) {
+        return;
+    }
+    mStopped = true;
+    mWatcher.Stop();
+    ClearProviders();
+
+    for (const auto& entry : mSessions) {
+        const auto& context = entry.second;
+        try {
+            if (context->hasStatusChanged) {
+                context->session.SessionStatusChanged(context->statusChanged);
+            }
+            if (context->hasMaxPduSizeChanged) {
+                context->session.MaxPduSizeChanged(context->maxPduSizeChanged);
+            }
+            context->session.MaintainConnection(false);
+            context->session.Close();
+        } catch (...) {
+        }
+    }
+    mSessions.clear();
+    mAdvertising = false;
+}
+
+BlenoWinRT::BlenoWinRT(const Napi::CallbackInfo& info)
+    : Napi::ObjectWrap<BlenoWinRT>(info) {
+}
+
+BlenoWinRT::~BlenoWinRT() {
+    if (mPeripheralManager) {
+        mPeripheralManager->Stop();
+    }
+}
+
+BLEPeripheralManager& BlenoWinRT::Manager(const Napi::CallbackInfo& info) {
+    if (!mPeripheralManager) {
+        throw Napi::Error::New(
+            info.Env(),
+            "Windows BLE manager is not initialized or has been stopped");
+    }
+    return *mPeripheralManager;
+}
+
+Napi::Value BlenoWinRT::Init(const Napi::CallbackInfo& info) {
+    if (mPeripheralManager) {
+        return info.Env().Undefined();
+    }
+
+    auto receiver = info.This().As<Napi::Object>();
+    auto emit = receiver.Get("emit");
+    if (!emit.IsFunction()) {
+        Napi::TypeError::New(info.Env(), "Binding is missing its emit function")
+            .ThrowAsJavaScriptException();
+        return info.Env().Undefined();
+    }
+
+    mPeripheralManager = std::make_unique<BLEPeripheralManager>(
+        receiver,
+        emit.As<Napi::Function>());
+    mPeripheralManager->Start();
+    return info.Env().Undefined();
+}
+
+Napi::Value BlenoWinRT::Stop(const Napi::CallbackInfo& info) {
+    if (mPeripheralManager) {
+        mPeripheralManager->Stop();
+        mPeripheralManager.reset();
+    }
+    return info.Env().Undefined();
+}
+
+Napi::Value BlenoWinRT::StartAdvertising(const Napi::CallbackInfo& info) {
+    if (info.Length() < 2 || !info[0].IsString() || !info[1].IsArray()) {
+        Napi::TypeError::New(
+            info.Env(),
+            "startAdvertising expects a name and an array of service UUIDs")
+            .ThrowAsJavaScriptException();
+        return info.Env().Undefined();
+    }
+
+    try {
+        std::vector<winrt::guid> serviceUuids;
+        auto uuids = info[1].As<Napi::Array>();
+        serviceUuids.reserve(uuids.Length());
+        for (uint32_t index = 0; index < uuids.Length(); ++index) {
+            serviceUuids.push_back(ToGuid(uuids.Get(index).ToString().Utf8Value()));
+        }
+        Manager(info).StartAdvertising(
+            info[0].As<Napi::String>().Utf8Value(),
+            serviceUuids);
+    } catch (const Napi::Error& error) {
+        error.ThrowAsJavaScriptException();
+    } catch (const std::exception& error) {
+        Napi::TypeError::New(info.Env(), error.what()).ThrowAsJavaScriptException();
+    }
+    return info.Env().Undefined();
+}
+
+Napi::Value BlenoWinRT::StopAdvertising(const Napi::CallbackInfo& info) {
+    try {
+        Manager(info).StopAdvertising();
+    } catch (const Napi::Error& error) {
+        error.ThrowAsJavaScriptException();
+    }
+    return info.Env().Undefined();
+}
+
+Napi::Value BlenoWinRT::StartAdvertisingIBeacon(
+    const Napi::CallbackInfo& info) {
+    try {
+        Manager(info).ReportUnsupportedAdvertising("iBeacon advertising");
+    } catch (const Napi::Error& error) {
+        error.ThrowAsJavaScriptException();
+    }
+    return info.Env().Undefined();
+}
+
+Napi::Value BlenoWinRT::StartAdvertisingWithEIRData(
+    const Napi::CallbackInfo& info) {
+    try {
+        Manager(info).ReportUnsupportedAdvertising("Raw EIR advertising");
+    } catch (const Napi::Error& error) {
+        error.ThrowAsJavaScriptException();
+    }
+    return info.Env().Undefined();
+}
+
+Napi::Value BlenoWinRT::SetServices(const Napi::CallbackInfo& info) {
+    if (info.Length() < 1 || !info[0].IsArray()) {
+        Napi::TypeError::New(info.Env(), "setServices expects an array")
+            .ThrowAsJavaScriptException();
+        return info.Env().Undefined();
+    }
+
+    try {
+        Manager(info).SetServices(ParseServices(info[0].As<Napi::Array>()));
+    } catch (const Napi::Error& error) {
+        error.ThrowAsJavaScriptException();
+    } catch (const std::exception& error) {
+        Napi::TypeError::New(info.Env(), error.what()).ThrowAsJavaScriptException();
+    }
+    return info.Env().Undefined();
+}
+
+Napi::Value BlenoWinRT::Disconnect(const Napi::CallbackInfo& info) {
+    try {
+        std::string connection;
+        if (info.Length() > 0 && !info[0].IsNull() && !info[0].IsUndefined()) {
+            connection = info[0].ToString().Utf8Value();
+        }
+        Manager(info).Disconnect(connection);
+    } catch (const Napi::Error& error) {
+        error.ThrowAsJavaScriptException();
+    }
+    return info.Env().Undefined();
+}
+
+Napi::Value BlenoWinRT::UpdateRssi(const Napi::CallbackInfo& info) {
+    Napi::Error::New(
+        info.Env(),
+        "Peer RSSI is not available from the native Windows GATT server API")
+        .ThrowAsJavaScriptException();
+    return info.Env().Undefined();
+}
+
+Napi::Function BlenoWinRT::GetClass(Napi::Env env) {
+    return DefineClass(env, "BlenoWinRT", {
+        InstanceMethod("init", &BlenoWinRT::Init),
+        InstanceMethod("stop", &BlenoWinRT::Stop),
+        InstanceMethod("startAdvertising", &BlenoWinRT::StartAdvertising),
+        InstanceMethod("startAdvertisingIBeacon", &BlenoWinRT::StartAdvertisingIBeacon),
+        InstanceMethod(
+            "startAdvertisingWithEIRData",
+            &BlenoWinRT::StartAdvertisingWithEIRData),
+        InstanceMethod("stopAdvertising", &BlenoWinRT::StopAdvertising),
+        InstanceMethod("setServices", &BlenoWinRT::SetServices),
+        InstanceMethod("disconnect", &BlenoWinRT::Disconnect),
+        InstanceMethod("updateRssi", &BlenoWinRT::UpdateRssi),
+    });
+}
+
+Napi::Object InitModule(Napi::Env env, Napi::Object exports) {
+    try {
+        winrt::init_apartment(winrt::apartment_type::multi_threaded);
+    } catch (const winrt::hresult_error& error) {
+        if (error.code() != RPC_E_CHANGED_MODE) {
+            Napi::Error::New(env, HResultMessage(error)).ThrowAsJavaScriptException();
+            return exports;
+        }
+    }
+
+    exports.Set("BlenoWinRT", BlenoWinRT::GetClass(env));
+    return exports;
+}
+
+NODE_API_MODULE(addon, InitModule)

--- a/lib/win/src/bleno_winrt.h
+++ b/lib/win/src/bleno_winrt.h
@@ -30,6 +30,7 @@ struct CharacteristicDefinition {
     bool hasStaticValue{ false };
     Data staticValue;
     std::string userDescription;
+    std::vector<winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattPresentationFormat> presentationFormats;
     std::vector<DescriptorDefinition> descriptors;
     std::shared_ptr<EmitCharacteristic> emitter;
 };
@@ -107,6 +108,7 @@ private:
 
     std::recursive_mutex mMutex;
     bool mAdvertising{ false };
+    bool mWarnedAboutName{ false };
     std::atomic<bool> mStopped{ false };
     AdapterState mRadioState{ AdapterState::Initial };
     std::string mName;

--- a/lib/win/src/bleno_winrt.h
+++ b/lib/win/src/bleno_winrt.h
@@ -42,7 +42,10 @@ struct ServiceDefinition {
 
 class BLEPeripheralManager {
 public:
-    BLEPeripheralManager(const Napi::Value& receiver, const Napi::Function& callback);
+    BLEPeripheralManager(
+        const Napi::Value& receiver,
+        const Napi::Function& callback,
+        bool extendedAdvertising = false);
     ~BLEPeripheralManager();
 
     void Start();
@@ -109,6 +112,8 @@ private:
     std::recursive_mutex mMutex;
     bool mAdvertising{ false };
     bool mWarnedAboutName{ false };
+    bool mWarnedAboutExtended{ false };
+    bool mExtendedAdvertising{ false };
     std::atomic<bool> mStopped{ false };
     AdapterState mRadioState{ AdapterState::Initial };
     std::string mName;
@@ -140,4 +145,5 @@ public:
 private:
     BLEPeripheralManager& Manager(const Napi::CallbackInfo& info);
     std::unique_ptr<BLEPeripheralManager> mPeripheralManager;
+    bool mExtendedAdvertising{ false };
 };

--- a/lib/win/src/bleno_winrt.h
+++ b/lib/win/src/bleno_winrt.h
@@ -1,0 +1,141 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include <napi.h>
+#include <winrt/Windows.Devices.Bluetooth.h>
+#include <winrt/Windows.Devices.Bluetooth.GenericAttributeProfile.h>
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Foundation.Collections.h>
+
+#include "callbacks.h"
+#include "radio_watcher.h"
+
+struct DescriptorDefinition {
+    winrt::guid uuid;
+    Data value;
+};
+
+struct CharacteristicDefinition {
+    winrt::guid uuid;
+    winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattCharacteristicProperties properties;
+    winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattProtectionLevel readProtection;
+    winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattProtectionLevel writeProtection;
+    bool hasStaticValue{ false };
+    Data staticValue;
+    std::string userDescription;
+    std::vector<DescriptorDefinition> descriptors;
+    std::shared_ptr<EmitCharacteristic> emitter;
+};
+
+struct ServiceDefinition {
+    winrt::guid uuid;
+    std::vector<CharacteristicDefinition> characteristics;
+};
+
+class BLEPeripheralManager {
+public:
+    BLEPeripheralManager(const Napi::Value& receiver, const Napi::Function& callback);
+    ~BLEPeripheralManager();
+
+    void Start();
+    void StartAdvertising(
+        const std::string& name,
+        const std::vector<winrt::guid>& serviceUuids);
+    void ReportUnsupportedAdvertising(const std::string& feature);
+    void StopAdvertising();
+    void SetServices(const std::vector<ServiceDefinition>& services);
+    void Disconnect(const std::string& connection = {});
+    void Stop() noexcept;
+
+private:
+    using GattLocalCharacteristic =
+        winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattLocalCharacteristic;
+    using GattServiceProvider =
+        winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattServiceProvider;
+    using GattSession =
+        winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattSession;
+    using GattSubscribedClient =
+        winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattSubscribedClient;
+
+    struct CharacteristicContext {
+        GattLocalCharacteristic characteristic{ nullptr };
+        std::shared_ptr<EmitCharacteristic> emitter;
+        std::map<std::string, GattSubscribedClient> subscribers;
+        winrt::event_token readRequested;
+        winrt::event_token writeRequested;
+        winrt::event_token subscribedClientsChanged;
+        bool hasReadRequested{ false };
+        bool hasWriteRequested{ false };
+        bool hasSubscribedClientsChanged{ false };
+    };
+
+    struct ProviderContext {
+        GattServiceProvider provider{ nullptr };
+        winrt::event_token advertisementStatusChanged;
+        bool hasAdvertisementStatusChanged{ false };
+    };
+
+    struct SessionContext {
+        GattSession session{ nullptr };
+        winrt::event_token statusChanged;
+        winrt::event_token maxPduSizeChanged;
+        bool hasStatusChanged{ false };
+        bool hasMaxPduSizeChanged{ false };
+    };
+
+    void StartProviders();
+    void ClearProviders() noexcept;
+    void EnsureSession(const GattSession& session);
+    void HandleSessionClosed(const std::string& connection) noexcept;
+    void HandleRead(
+        const std::shared_ptr<CharacteristicContext>& context,
+        const winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattReadRequestedEventArgs& args);
+    void HandleWrite(
+        const std::shared_ptr<CharacteristicContext>& context,
+        const winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattWriteRequestedEventArgs& args);
+    void HandleSubscribersChanged(
+        const std::shared_ptr<CharacteristicContext>& context) noexcept;
+    static void UnregisterCharacteristic(
+        const std::shared_ptr<CharacteristicContext>& context) noexcept;
+
+    std::recursive_mutex mMutex;
+    bool mAdvertising{ false };
+    std::atomic<bool> mStopped{ false };
+    AdapterState mRadioState{ AdapterState::Initial };
+    std::string mName;
+    std::vector<winrt::guid> mAdvertisedServiceUuids;
+    std::vector<ProviderContext> mProviders;
+    std::vector<std::shared_ptr<CharacteristicContext>> mCharacteristics;
+    std::map<std::string, std::shared_ptr<SessionContext>> mSessions;
+    RadioWatcher mWatcher;
+    Emit mEmit;
+};
+
+class BlenoWinRT : public Napi::ObjectWrap<BlenoWinRT> {
+public:
+    explicit BlenoWinRT(const Napi::CallbackInfo& info);
+    ~BlenoWinRT() override;
+
+    Napi::Value Init(const Napi::CallbackInfo& info);
+    Napi::Value Stop(const Napi::CallbackInfo& info);
+    Napi::Value StartAdvertising(const Napi::CallbackInfo& info);
+    Napi::Value StartAdvertisingIBeacon(const Napi::CallbackInfo& info);
+    Napi::Value StartAdvertisingWithEIRData(const Napi::CallbackInfo& info);
+    Napi::Value StopAdvertising(const Napi::CallbackInfo& info);
+    Napi::Value SetServices(const Napi::CallbackInfo& info);
+    Napi::Value Disconnect(const Napi::CallbackInfo& info);
+    Napi::Value UpdateRssi(const Napi::CallbackInfo& info);
+
+    static Napi::Function GetClass(Napi::Env env);
+
+private:
+    BLEPeripheralManager& Manager(const Napi::CallbackInfo& info);
+    std::unique_ptr<BLEPeripheralManager> mPeripheralManager;
+};

--- a/lib/win/src/callbacks.cc
+++ b/lib/win/src/callbacks.cc
@@ -1,0 +1,204 @@
+#include "callbacks.h"
+
+#include "ThreadSafeCallback.h"
+
+namespace {
+
+Napi::Buffer<uint8_t> ToBuffer(Napi::Env env, const Data& data) {
+    if (data.empty()) {
+        return Napi::Buffer<uint8_t>::New(env, 0);
+    }
+    return Napi::Buffer<uint8_t>::Copy(env, data.data(), data.size());
+}
+
+Data FromBuffer(const Napi::Value& value) {
+    if (!value.IsBuffer()) {
+        return {};
+    }
+
+    auto buffer = value.As<Napi::Buffer<uint8_t>>();
+    return Data(buffer.Data(), buffer.Data() + buffer.Length());
+}
+
+}  // namespace
+
+void Emit::Wrap(const Napi::Value& receiver, const Napi::Function& callback) {
+    mCallback = std::make_shared<ThreadSafeCallback>(receiver, callback);
+}
+
+void Emit::Platform(const std::string& platform) {
+    mCallback->call([platform](Napi::Env env, std::vector<napi_value>& args) {
+        args = {
+            Napi::String::New(env, "platform"),
+            Napi::String::New(env, platform),
+        };
+    });
+}
+
+void Emit::StateChange(const std::string& state) {
+    mCallback->call([state](Napi::Env env, std::vector<napi_value>& args) {
+        args = {
+            Napi::String::New(env, "stateChange"),
+            Napi::String::New(env, state),
+        };
+    });
+}
+
+void Emit::AdvertisingStart(const std::string& error) {
+    mCallback->call([error](Napi::Env env, std::vector<napi_value>& args) {
+        args = {
+            Napi::String::New(env, "advertisingStart"),
+            error.empty()
+                ? env.Null()
+                : Napi::Error::New(env, error).Value(),
+        };
+    });
+}
+
+void Emit::AdvertisingStop() {
+    mCallback->call([](Napi::Env env, std::vector<napi_value>& args) {
+        args = { Napi::String::New(env, "advertisingStop") };
+    });
+}
+
+void Emit::ServicesSet(const std::string& error) {
+    mCallback->call([error](Napi::Env env, std::vector<napi_value>& args) {
+        args = {
+            Napi::String::New(env, "servicesSet"),
+            error.empty()
+                ? env.Null()
+                : Napi::Error::New(env, error).Value(),
+        };
+    });
+}
+
+void Emit::Accept(const std::string& connection) {
+    mCallback->call([connection](Napi::Env env, std::vector<napi_value>& args) {
+        auto id = Napi::String::New(env, connection);
+        args = { Napi::String::New(env, "accept"), id, id };
+    });
+}
+
+void Emit::Disconnect(const std::string& connection) {
+    mCallback->call([connection](Napi::Env env, std::vector<napi_value>& args) {
+        auto id = Napi::String::New(env, connection);
+        args = { Napi::String::New(env, "disconnect"), id, id };
+    });
+}
+
+void Emit::MtuChange(uint16_t mtu) {
+    mCallback->call([mtu](Napi::Env env, std::vector<napi_value>& args) {
+        args = {
+            Napi::String::New(env, "mtuChange"),
+            Napi::Number::New(env, mtu),
+        };
+    });
+}
+
+void Emit::RssiUpdate(int16_t rssi) {
+    mCallback->call([rssi](Napi::Env env, std::vector<napi_value>& args) {
+        args = {
+            Napi::String::New(env, "rssiUpdate"),
+            Napi::Number::New(env, rssi),
+        };
+    });
+}
+
+void EmitCharacteristic::Wrap(
+    const Napi::Value& receiver,
+    const Napi::Function& callback) {
+    mCallback = std::make_shared<ThreadSafeCallback>(receiver, callback);
+}
+
+void EmitCharacteristic::ReadRequest(
+    const std::string& connection,
+    uint16_t offset,
+    std::function<void(uint16_t, const Data&)> completion) {
+    mCallback->call(
+        [connection, offset, completion](
+            Napi::Env env,
+            std::vector<napi_value>& args) {
+            auto callback = Napi::Function::New(
+                env,
+                [completion](const Napi::CallbackInfo& info) {
+                    const auto result = info.Length() > 0 && info[0].IsNumber()
+                        ? info[0].As<Napi::Number>().Uint32Value()
+                        : 0x0e;
+                    const auto data = info.Length() > 1
+                        ? FromBuffer(info[1])
+                        : Data{};
+                    completion(static_cast<uint16_t>(result), data);
+                });
+
+            args = {
+                Napi::String::New(env, "readRequest"),
+                Napi::String::New(env, connection),
+                Napi::Number::New(env, offset),
+                callback,
+            };
+        });
+}
+
+void EmitCharacteristic::WriteRequest(
+    const std::string& connection,
+    const Data& data,
+    uint16_t offset,
+    bool withoutResponse,
+    std::function<void(uint16_t)> completion) {
+    mCallback->call(
+        [connection, data, offset, withoutResponse, completion](
+            Napi::Env env,
+            std::vector<napi_value>& args) {
+            auto callback = Napi::Function::New(
+                env,
+                [completion](const Napi::CallbackInfo& info) {
+                    const auto result = info.Length() > 0 && info[0].IsNumber()
+                        ? info[0].As<Napi::Number>().Uint32Value()
+                        : 0x0e;
+                    completion(static_cast<uint16_t>(result));
+                });
+
+            args = {
+                Napi::String::New(env, "writeRequest"),
+                Napi::String::New(env, connection),
+                ToBuffer(env, data),
+                Napi::Number::New(env, offset),
+                Napi::Boolean::New(env, withoutResponse),
+                callback,
+            };
+        });
+}
+
+void EmitCharacteristic::Subscribe(
+    const std::string& connection,
+    uint16_t maxValueSize,
+    std::function<void(const Data&)> completion) {
+    mCallback->call(
+        [connection, maxValueSize, completion](
+            Napi::Env env,
+            std::vector<napi_value>& args) {
+            auto callback = Napi::Function::New(
+                env,
+                [completion](const Napi::CallbackInfo& info) {
+                    if (info.Length() > 0 && info[0].IsBuffer()) {
+                        completion(FromBuffer(info[0]));
+                    }
+                });
+
+            args = {
+                Napi::String::New(env, "subscribe"),
+                Napi::String::New(env, connection),
+                Napi::Number::New(env, maxValueSize),
+                callback,
+            };
+        });
+}
+
+void EmitCharacteristic::Unsubscribe(const std::string& connection) {
+    mCallback->call([connection](Napi::Env env, std::vector<napi_value>& args) {
+        args = {
+            Napi::String::New(env, "unsubscribe"),
+            Napi::String::New(env, connection),
+        };
+    });
+}

--- a/lib/win/src/callbacks.cc
+++ b/lib/win/src/callbacks.cc
@@ -44,6 +44,15 @@ void Emit::StateChange(const std::string& state) {
     });
 }
 
+void Emit::Warning(const std::string& message) {
+    mCallback->call([message](Napi::Env env, std::vector<napi_value>& args) {
+        args = {
+            Napi::String::New(env, "warning"),
+            Napi::String::New(env, message),
+        };
+    });
+}
+
 void Emit::AdvertisingStart(const std::string& error) {
     mCallback->call([error](Napi::Env env, std::vector<napi_value>& args) {
         args = {

--- a/lib/win/src/callbacks.h
+++ b/lib/win/src/callbacks.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <napi.h>
+
+class ThreadSafeCallback;
+
+using Data = std::vector<uint8_t>;
+
+class Emit {
+public:
+    void Wrap(const Napi::Value& receiver, const Napi::Function& callback);
+    void Platform(const std::string& platform);
+    void StateChange(const std::string& state);
+    void AdvertisingStart(const std::string& error = {});
+    void AdvertisingStop();
+    void ServicesSet(const std::string& error = {});
+    void Accept(const std::string& connection);
+    void Disconnect(const std::string& connection);
+    void MtuChange(uint16_t mtu);
+    void RssiUpdate(int16_t rssi);
+
+private:
+    std::shared_ptr<ThreadSafeCallback> mCallback;
+};
+
+class EmitCharacteristic {
+public:
+    void Wrap(const Napi::Value& receiver, const Napi::Function& callback);
+    void ReadRequest(
+        const std::string& connection,
+        uint16_t offset,
+        std::function<void(uint16_t, const Data&)> completion);
+    void WriteRequest(
+        const std::string& connection,
+        const Data& data,
+        uint16_t offset,
+        bool withoutResponse,
+        std::function<void(uint16_t)> completion);
+    void Subscribe(
+        const std::string& connection,
+        uint16_t maxValueSize,
+        std::function<void(const Data&)> completion);
+    void Unsubscribe(const std::string& connection);
+
+private:
+    std::shared_ptr<ThreadSafeCallback> mCallback;
+};

--- a/lib/win/src/callbacks.h
+++ b/lib/win/src/callbacks.h
@@ -17,6 +17,7 @@ public:
     void Wrap(const Napi::Value& receiver, const Napi::Function& callback);
     void Platform(const std::string& platform);
     void StateChange(const std::string& state);
+    void Warning(const std::string& message);
     void AdvertisingStart(const std::string& error = {});
     void AdvertisingStop();
     void ServicesSet(const std::string& error = {});

--- a/lib/win/src/radio_watcher.cc
+++ b/lib/win/src/radio_watcher.cc
@@ -1,0 +1,170 @@
+#include "radio_watcher.h"
+
+#include <windows.h>
+#include <winrt/Windows.Devices.Bluetooth.h>
+
+using winrt::Windows::Devices::Bluetooth::BluetoothAdapter;
+using winrt::Windows::Devices::Radios::RadioState;
+
+const char* AdapterStateToString(AdapterState state) {
+    switch (state) {
+    case AdapterState::On:
+        return "poweredOn";
+    case AdapterState::Off:
+    case AdapterState::Disabled:
+        return "poweredOff";
+    case AdapterState::Unsupported:
+        return "unsupported";
+    case AdapterState::Unauthorized:
+        return "unauthorized";
+    default:
+        return "unknown";
+    }
+}
+
+RadioWatcher::RadioWatcher()
+    : mWatcher(
+        winrt::Windows::Devices::Enumeration::DeviceInformation::CreateWatcher(
+            RadioInterfaceSelector)) {
+    mAdded = mWatcher.Added(
+        winrt::auto_revoke,
+        { this, &RadioWatcher::OnAdded });
+    mUpdated = mWatcher.Updated(
+        winrt::auto_revoke,
+        { this, &RadioWatcher::OnUpdated });
+    mRemoved = mWatcher.Removed(
+        winrt::auto_revoke,
+        { this, &RadioWatcher::OnRemoved });
+    mCompleted = mWatcher.EnumerationCompleted(
+        winrt::auto_revoke,
+        { this, &RadioWatcher::OnCompleted });
+}
+
+RadioWatcher::~RadioWatcher() {
+    Stop();
+}
+
+void RadioWatcher::Start(std::function<void(AdapterState)> callback) {
+    mCallback = std::move(callback);
+    mStopped = false;
+    mEnumerating = true;
+    mWatcher.Start();
+}
+
+void RadioWatcher::Stop() noexcept {
+    if (mStopped.exchange(true)) {
+        return;
+    }
+
+    try {
+        mRadioStateChanged.revoke();
+        const auto status = mWatcher.Status();
+        if (status == winrt::Windows::Devices::Enumeration::DeviceWatcherStatus::Started ||
+            status == winrt::Windows::Devices::Enumeration::DeviceWatcherStatus::EnumerationCompleted) {
+            mWatcher.Stop();
+        }
+    } catch (...) {
+    }
+    mCallback = nullptr;
+    mRadio = nullptr;
+}
+
+winrt::fire_and_forget RadioWatcher::Refresh() {
+    try {
+        auto adapter = co_await BluetoothAdapter::GetDefaultAsync();
+        if (mStopped) {
+            co_return;
+        }
+
+        if (!adapter ||
+            !adapter.IsLowEnergySupported() ||
+            !adapter.IsPeripheralRoleSupported()) {
+            mRadioStateChanged.revoke();
+            mRadio = nullptr;
+            Publish(AdapterState::Unsupported);
+            co_return;
+        }
+
+        auto radio = co_await adapter.GetRadioAsync();
+        if (mStopped) {
+            co_return;
+        }
+
+        if (!radio) {
+            mRadioStateChanged.revoke();
+            mRadio = nullptr;
+            Publish(AdapterState::Unsupported);
+            co_return;
+        }
+
+        if (!mRadio || radio != mRadio) {
+            mRadioStateChanged.revoke();
+            mRadio = radio;
+            mRadioStateChanged = mRadio.StateChanged(
+                winrt::auto_revoke,
+                [this](const auto& sender, const auto&) {
+                    if (!mStopped) {
+                        Publish(static_cast<AdapterState>(sender.State()));
+                    }
+                });
+        }
+
+        Publish(static_cast<AdapterState>(mRadio.State()));
+    } catch (const winrt::hresult_error& error) {
+        if (!mStopped) {
+            mRadioStateChanged.revoke();
+            mRadio = nullptr;
+            Publish(
+                error.code() == E_ACCESSDENIED
+                    ? AdapterState::Unauthorized
+                    : AdapterState::Unsupported);
+        }
+    } catch (...) {
+        if (!mStopped) {
+            mRadioStateChanged.revoke();
+            mRadio = nullptr;
+            Publish(AdapterState::Unsupported);
+        }
+    }
+}
+
+void RadioWatcher::OnAdded(
+    const winrt::Windows::Devices::Enumeration::DeviceWatcher&,
+    const winrt::Windows::Devices::Enumeration::DeviceInformation&) {
+    if (!mEnumerating && !mStopped) {
+        Refresh();
+    }
+}
+
+void RadioWatcher::OnUpdated(
+    const winrt::Windows::Devices::Enumeration::DeviceWatcher&,
+    const winrt::Windows::Devices::Enumeration::DeviceInformationUpdate&) {
+    if (!mStopped) {
+        Refresh();
+    }
+}
+
+void RadioWatcher::OnRemoved(
+    const winrt::Windows::Devices::Enumeration::DeviceWatcher&,
+    const winrt::Windows::Devices::Enumeration::DeviceInformationUpdate&) {
+    if (!mStopped) {
+        Refresh();
+    }
+}
+
+void RadioWatcher::OnCompleted(
+    const winrt::Windows::Devices::Enumeration::DeviceWatcher&,
+    const winrt::Windows::Foundation::IInspectable&) {
+    mEnumerating = false;
+    if (!mStopped) {
+        Refresh();
+    }
+}
+
+void RadioWatcher::Publish(AdapterState state) {
+    if (mStopped || !mCallback || state == mLastState) {
+        return;
+    }
+    mLastState = state;
+    mCallback(state);
+}

--- a/lib/win/src/radio_watcher.h
+++ b/lib/win/src/radio_watcher.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <atomic>
+#include <functional>
+
+#include <winrt/Windows.Devices.Enumeration.h>
+#include <winrt/Windows.Devices.Radios.h>
+#include <winrt/Windows.Foundation.h>
+
+enum class AdapterState : int32_t {
+    Unauthorized = -3,
+    Initial = -2,
+    Unsupported = -1,
+    Unknown = static_cast<int32_t>(
+        winrt::Windows::Devices::Radios::RadioState::Unknown),
+    On = static_cast<int32_t>(
+        winrt::Windows::Devices::Radios::RadioState::On),
+    Off = static_cast<int32_t>(
+        winrt::Windows::Devices::Radios::RadioState::Off),
+    Disabled = static_cast<int32_t>(
+        winrt::Windows::Devices::Radios::RadioState::Disabled),
+};
+
+const char* AdapterStateToString(AdapterState state);
+
+class RadioWatcher {
+public:
+    RadioWatcher();
+    ~RadioWatcher();
+
+    void Start(std::function<void(AdapterState)> callback);
+    void Stop() noexcept;
+
+private:
+    static constexpr const wchar_t* RadioInterfaceSelector =
+        L"System.Devices.InterfaceClassGuid:=\"{A8804298-2D5F-42E3-9531-9C8C39EB29CE}\"";
+
+    winrt::fire_and_forget Refresh();
+    void OnAdded(
+        const winrt::Windows::Devices::Enumeration::DeviceWatcher&,
+        const winrt::Windows::Devices::Enumeration::DeviceInformation&);
+    void OnUpdated(
+        const winrt::Windows::Devices::Enumeration::DeviceWatcher&,
+        const winrt::Windows::Devices::Enumeration::DeviceInformationUpdate&);
+    void OnRemoved(
+        const winrt::Windows::Devices::Enumeration::DeviceWatcher&,
+        const winrt::Windows::Devices::Enumeration::DeviceInformationUpdate&);
+    void OnCompleted(
+        const winrt::Windows::Devices::Enumeration::DeviceWatcher&,
+        const winrt::Windows::Foundation::IInspectable&);
+    void Publish(AdapterState state);
+
+    std::atomic<bool> mStopped{ true };
+    std::atomic<bool> mEnumerating{ false };
+    AdapterState mLastState{ AdapterState::Initial };
+    std::function<void(AdapterState)> mCallback;
+
+    winrt::Windows::Devices::Enumeration::DeviceWatcher mWatcher{ nullptr };
+    winrt::Windows::Devices::Radios::Radio mRadio{ nullptr };
+
+    winrt::Windows::Devices::Enumeration::DeviceWatcher::Added_revoker mAdded;
+    winrt::Windows::Devices::Enumeration::DeviceWatcher::Updated_revoker mUpdated;
+    winrt::Windows::Devices::Enumeration::DeviceWatcher::Removed_revoker mRemoved;
+    winrt::Windows::Devices::Enumeration::DeviceWatcher::EnumerationCompleted_revoker mCompleted;
+    winrt::Windows::Devices::Radios::Radio::StateChanged_revoker mRadioStateChanged;
+};

--- a/lib/win/src/winrt_cpp.cc
+++ b/lib/win/src/winrt_cpp.cc
@@ -1,0 +1,96 @@
+#include "winrt_cpp.h"
+
+#include <algorithm>
+#include <cctype>
+#include <stdexcept>
+
+#include <winrt/Windows.Devices.Bluetooth.h>
+
+namespace {
+
+std::string NormalizeUuid(std::string uuid) {
+    uuid.erase(
+        std::remove_if(
+            uuid.begin(),
+            uuid.end(),
+            [](char value) { return value == '-' || value == '{' || value == '}'; }),
+        uuid.end());
+    std::transform(
+        uuid.begin(),
+        uuid.end(),
+        uuid.begin(),
+        [](unsigned char value) { return static_cast<char>(std::tolower(value)); });
+
+    if (!std::all_of(uuid.begin(), uuid.end(), [](unsigned char value) {
+        return std::isxdigit(value) != 0;
+    })) {
+        throw std::invalid_argument("UUID contains non-hexadecimal characters");
+    }
+
+    if (uuid.size() == 4) {
+        uuid = "0000" + uuid + "00001000800000805f9b34fb";
+    } else if (uuid.size() == 8) {
+        uuid += "00001000800000805f9b34fb";
+    }
+
+    if (uuid.size() != 32) {
+        throw std::invalid_argument("UUID must be 16, 32, or 128 bits");
+    }
+
+    uuid.insert(8, "-");
+    uuid.insert(13, "-");
+    uuid.insert(18, "-");
+    uuid.insert(23, "-");
+    return uuid;
+}
+
+}  // namespace
+
+winrt::guid ToGuid(const std::string& uuid) {
+    return winrt::guid(winrt::to_hstring(NormalizeUuid(uuid)));
+}
+
+winrt::Windows::Storage::Streams::IBuffer ToBuffer(const Data& data) {
+    winrt::Windows::Storage::Streams::Buffer buffer(
+        static_cast<uint32_t>(data.size()));
+    buffer.Length(static_cast<uint32_t>(data.size()));
+    if (!data.empty()) {
+        std::copy(data.begin(), data.end(), buffer.data());
+    }
+    return buffer;
+}
+
+Data FromBuffer(const winrt::Windows::Storage::Streams::IBuffer& buffer) {
+    if (!buffer || buffer.Length() == 0) {
+        return {};
+    }
+    return Data(buffer.data(), buffer.data() + buffer.Length());
+}
+
+Data FromNapiValue(const Napi::Value& value) {
+    if (value.IsBuffer()) {
+        auto buffer = value.As<Napi::Buffer<uint8_t>>();
+        return Data(buffer.Data(), buffer.Data() + buffer.Length());
+    }
+    if (value.IsString()) {
+        auto string = value.As<Napi::String>().Utf8Value();
+        return Data(string.begin(), string.end());
+    }
+    return {};
+}
+
+std::string ToConnectionId(
+    const winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattSession& session) {
+    if (!session || !session.DeviceId()) {
+        return "unknown";
+    }
+    return winrt::to_string(session.DeviceId().Id());
+}
+
+std::string HResultMessage(const winrt::hresult_error& error) {
+    auto message = winrt::to_string(error.message());
+    if (!message.empty()) {
+        return message;
+    }
+    return "WinRT error " + std::to_string(error.code().value);
+}

--- a/lib/win/src/winrt_cpp.h
+++ b/lib/win/src/winrt_cpp.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <napi.h>
+#include <winrt/Windows.Devices.Bluetooth.GenericAttributeProfile.h>
+#include <winrt/Windows.Storage.Streams.h>
+
+using Data = std::vector<uint8_t>;
+
+winrt::guid ToGuid(const std::string& uuid);
+winrt::Windows::Storage::Streams::IBuffer ToBuffer(const Data& data);
+Data FromBuffer(const winrt::Windows::Storage::Streams::IBuffer& buffer);
+Data FromNapiValue(const Napi::Value& value);
+std::string ToConnectionId(
+    const winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::GattSession& session);
+std::string HResultMessage(const winrt::hresult_error& error);

--- a/test/bleno.test.js
+++ b/test/bleno.test.js
@@ -1,0 +1,29 @@
+const EventEmitter = require('events');
+const should = require('should');
+
+const Bleno = require('../lib/bleno');
+
+class MockBindings extends EventEmitter {
+  setServices () {
+  }
+}
+
+describe('Bleno', function () {
+  it('should deliver service setup errors to the callback and error event', function (done) {
+    const bindings = new MockBindings();
+    const bleno = new Bleno(bindings);
+    const expectedError = new Error('service setup failed');
+    let emittedError;
+
+    bleno.once('servicesSetError', (error) => {
+      emittedError = error;
+    });
+    bleno.setServices([], (error) => {
+      should(error).equal(expectedError);
+      should(emittedError).equal(expectedError);
+      done();
+    });
+
+    bindings.emit('servicesSet', expectedError);
+  });
+});


### PR DESCRIPTION
## What changed

- Added a native C++/WinRT GATT server binding for Windows.
- Added radio-state tracking, advertising lifecycle handling, dynamic services, characteristics and descriptors, read/write requests, notifications, indications, subscriptions, MTU updates, and connection lifecycle events.
- Made the WinRT binding the default on `win32`; the raw HCI backend remains available with `withBindings('hci')`.
- Added Windows build targets, binding resolution, TypeScript declarations, documentation, and service-setup error regression coverage.
- Documented manual `withBindings('win')` selection, handle-specific disconnects, platform requirements, supported features, and native API limitations.
- Hardened the shared thread-safe callback lifecycle used by native bindings.

## Why

Windows previously defaulted to raw HCI access, which requires a dedicated adapter and WinUSB driver. The native binding uses the normal Windows Bluetooth stack and exposes bleno's peripheral APIs through WinRT.

## Impact

Windows users with an adapter that supports the Bluetooth LE peripheral role can use the system Bluetooth driver. Raw EIR and iBeacon advertising, application-controlled local names, and peer RSSI reads are not available through this binding; these limitations are documented.

## Validation

- GitHub Build matrix passed, including native Windows x86 and x64 compilation, prebuild generation, and artifact upload.
- GitHub Test / Lint matrix passed on Node 18 and 20 across Linux, macOS, and Windows.
- Commit-message validation passed.
- Local clean install, lint, native macOS rebuild, and 25 tests passed.
- `npm pack --dry-run` includes the Windows sources.
